### PR TITLE
(maint) Update references from drone to harness

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "description": "Basic library for integrating CF into javascript applications.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/drone/ff-javascript-client-sdk.git"
+    "url": "git+https://github.com/harness/ff-javascript-client-sdk.git"
   },
   "dependencies": {
     "jwt-decode": "^3.1.2",
@@ -53,7 +53,7 @@
     "Drone"
   ],
   "bugs": {
-    "url": "https://github.com/drone/ff-javascript-client-sdk/issues"
+    "url": "https://github.com/harness/ff-javascript-client-sdk/issues"
   },
-  "homepage": "https://github.com/drone/ff-javascript-client-sdk#readme"
+  "homepage": "https://github.com/harness/ff-javascript-client-sdk#readme"
 }


### PR DESCRIPTION
Following the move of the repo we have renamed links to harness