### PR TITLE
Remove unnecessary comment from demo app

### DIFF
--- a/examples/vallina/index.html
+++ b/examples/vallina/index.html
@@ -9,8 +9,6 @@
   <body>
     <pre id="log"></pre>
 
-    <!-- This example shows how to use Harness Feature Flags JavaScript SDK for old browsers -->
-
     <script>
       var initialize = HarnessFFSDK.initialize
       var Event = HarnessFFSDK.Event


### PR DESCRIPTION
No need to indicate which browsers this is for, as it is still appropriate for newer browsers to illustrate a simple usage of the SDK.