### PR TITLE
feat: [FFM-6788]: Restrict metric incrementation

### DIFF
--- a/examples/preact/package-lock.json
+++ b/examples/preact/package-lock.json
@@ -18,7 +18,7 @@
     },
     "../..": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "event-source-polyfill": "1.0.31",

--- a/examples/react-redux/package-lock.json
+++ b/examples/react-redux/package-lock.json
@@ -27,7 +27,7 @@
     },
     "../..": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "event-source-polyfill": "1.0.31",

--- a/examples/react/package-lock.json
+++ b/examples/react/package-lock.json
@@ -15,7 +15,7 @@
     },
     "../..": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "event-source-polyfill": "1.0.31",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-javascript-client-sdk",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "event-source-polyfill": "1.0.31",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-javascript-client-sdk",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "author": "Harness",
   "license": "Apache-2.0",
   "main": "dist/sdk.cjs.js",


### PR DESCRIPTION
This PR restricts incrementing metrics to prevent all flags being marked as accessed on initial load. It also guards against triggering metrics with a `0` count.