### PR TITLE
chore: [FFM-7063]: Update slack-github-action

### DIFF
--- a/.github/workflows/notify_release.yml
+++ b/.github/workflows/notify_release.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Publish release details to slack ff-builds
         id: slack
-        uses: slackapi/slack-github-action@v1.17.0
+        uses: slackapi/slack-github-action@v1.23.0
         with:
           # For posting a rich message using Block Kit
           payload: |


### PR DESCRIPTION
This PR updates the version of `slackapi/slack-github-action` to a version which uses a version of Node that GitHub supports. No changes to the SDK are included in this.