### PR TITLE
(FFM-7896) Handle evaluation sse events

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -445,10 +445,22 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
     const handleFlagEvent = (event: StreamEvent): void => {
       switch (event.event) {
         case 'create':
-          setTimeout(() => fetchFlag(event.identifier), 1000) // Wait a bit before fetching evaluation due to https://harness.atlassian.net/browse/FFM-583
+          // if evaluation was sent in stream save it directly, else query for it
+          if (event.evaluation) {
+            registerEvaluation(event.evaluation)
+          } else {
+            setTimeout(() => fetchFlag(event.identifier), 1000) // Wait a bit before fetching evaluation due to https://harness.atlassian.net/browse/FFM-583
+          }
+          
           break
         case 'patch':
-          fetchFlag(event.identifier)
+          // if evaluation was sent in stream save it directly, else query for it
+          if (event.evaluation) {
+            registerEvaluation(event.evaluation)
+          } else {
+            fetchFlag(event.identifier)
+          }
+          
           break
         case 'delete':
           delete storage[event.identifier]

--- a/src/index.ts
+++ b/src/index.ts
@@ -446,7 +446,7 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
       switch (event.event) {
         case 'create':
           // if evaluation was sent in stream save it directly, else query for it
-          if (event.evaluation) {
+          if (isEvaluationValid(event.evaluation)) {
             registerEvaluation(event.evaluation)
           } else {
             setTimeout(() => fetchFlag(event.identifier), 1000) // Wait a bit before fetching evaluation due to https://harness.atlassian.net/browse/FFM-583
@@ -455,7 +455,7 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
           break
         case 'patch':
           // if evaluation was sent in stream save it directly, else query for it
-          if (event.evaluation) {
+          if (isEvaluationValid(event.evaluation)) {
             registerEvaluation(event.evaluation)
           } else {
             fetchFlag(event.identifier)
@@ -468,6 +468,15 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
           logDebug('Evaluation deleted', { message: event, storage })
           break
       }
+    }
+    
+    // check if Evaluation and it's fields are populated
+    const isEvaluationValid = (evaluation: Evaluation): boolean => { 
+      if (!evaluation || !evaluation.flag || !evaluation.identifier || !evaluation.kind || !evaluation.value) {
+        return false
+      }
+
+      return true
     }
 
     const handleSegmentEvent = (event: StreamEvent): void => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ export interface StreamEvent {
   domain: string
   identifier: string
   version: number
+  evaluation?: Evaluation
 }
 
 export enum Event {


### PR DESCRIPTION
**Changes**
If the flag evaluation is sent directly in the sse stream save it and don't query SaaS. 
If the flag evaluation isn't sent then query SaaS for the updated value as normal. 
It shouldn't happen but we have defensive code here that makes sure every field is correctly populated before we save, else we'll fallback to polling as normal. 

**Impact**
Once the stream is connected we can get and use updated flag values without needing to make any requests to SaaS, meaning lower latency and fewer network calls for customers sdks. 

https://github.com/harness/ff-javascript-client-sdk/assets/42169772/1b4718fc-6b40-4445-a5cd-a50e5afe1cdd


