### PR TITLE
(FFM-8144) Target group pre-evaluation logic

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ export interface StreamEvent {
   domain: string
   identifier: string
   version: number
-  evaluation?: Evaluation
+  evaluations?: Evaluation[]
 }
 
 export enum Event {


### PR DESCRIPTION
**Changes**
Support evaluations being sent directly through target-segment sse events.
Update flag events to also use the evaluations structure, matching the latest design changes on ff-server 