### PR TITLE
FFM-8141 - Add refreshEvaluations() API method

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,76 @@ If you need to support old browsers which don't support ES Module:
 </script>
 ```
 
+## Integration with web views on mobile devices
+
+The SDK can be used inside webviews on native mobile apps for iOS and Android. You will need to add some additional
+code to tell the SDK to update its local evaluations when the app comes to the foreground after being placed into
+the background. This will ensure the SDK has the latest evaluations as the SSE stream will not receive events while
+the app is suspended in the background. Similarly, you may want refresh the SDK if the network comes online after a
+period of no connectivity.
+
+The SDK provides a function on the client instance called `refreshEvaluations`. Calling this allows you to soft poll the
+servers for the latest evaluations. Note to avoid overloading the backend servers this function will only call out to the
+network after enough time has elapsed.
+
+### toForeground JS function
+
+Once you have a client instance (as shown above) add a function that can be easily invoked from the device's native language
+
+```typescript
+   function toForeground() {
+      client.refreshEvaluations()
+   }
+```
+
+
+### iOS
+
+On iOS add an observer to wait for [willEnterForegroundNotification](https://developer.apple.com/documentation/uikit/uiapplication/1622944-willenterforegroundnotification) on the [WKWebView](https://developer.apple.com/documentation/webkit/wkwebview) to call [evaluateJavaScript()](https://developer.apple.com/documentation/webkit/wkwebview/1415017-evaluatejavascript)
+
+
+```swift
+  _ = NotificationCenter.default.addObserver(
+      forName: UIApplication.willEnterForegroundNotification,
+      object: nil,
+      queue: .main
+  ) { (notification: Notification) in
+
+      if UIApplication.shared.applicationState == .background {
+
+          // tell the embedded JS SDK to refresh itself
+          getWebView().evaluateJavaScript("toForeground();") { (result, error) in
+             ...
+          }
+      }
+  }
+```
+
+### Android
+
+On Android register an [ActivityLifecycleCallbacks](https://developer.android.com/reference/android/app/Application.ActivityLifecycleCallbacks) listener and override [onActivityStarted()](https://developer.android.com/reference/android/app/Application.ActivityLifecycleCallbacks#onActivityStarted(android.app.Activity)) (API level 29) then once a foreground event arrives you can call [evaluateJavascript()](https://developer.android.com/reference/android/webkit/WebView#evaluateJavascript(java.lang.String,%20android.webkit.ValueCallback%3Cjava.lang.String%3E)) on the [WebView](https://developer.android.com/reference/android/webkit/WebView)
+
+
+```java
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+      super.onCreate(savedInstanceState);
+
+      registerActivityLifecycleCallbacks(new Application.ActivityLifecycleCallbacks() {
+
+          @Override
+          public void onActivityStarted(@NonNull Activity activity) {
+              WebView webView = findViewById(R.id.webview);
+              // tell the embedded JS SDK to refresh itself
+              webView.evaluateJavascript("toForeground();", (result) -> {
+                  ...
+              });
+          }
+      });
+  }
+```
+
+
 ## License
 
 Apache version 2.

--- a/README.md
+++ b/README.md
@@ -225,75 +225,9 @@ If you need to support old browsers which don't support ES Module:
 </script>
 ```
 
-## Integration with web views on mobile devices
+## Further reading
 
-The SDK can be used inside webviews on native mobile apps for iOS and Android. You will need to add some additional
-code to tell the SDK to update its local evaluations when the app comes to the foreground after being placed into
-the background. This will ensure the SDK has the latest evaluations as the SSE stream will not receive events while
-the app is suspended in the background. Similarly, you may want refresh the SDK if the network comes online after a
-period of no connectivity.
-
-The SDK provides a function on the client instance called `refreshEvaluations`. Calling this allows you to soft poll the
-servers for the latest evaluations. Note to avoid overloading the backend servers this function will only call out to the
-network after enough time has elapsed.
-
-### toForeground JS function
-
-Once you have a client instance (as shown above) add a function that can be easily invoked from the device's native language
-
-```typescript
-   function toForeground() {
-      client.refreshEvaluations()
-   }
-```
-
-
-### iOS
-
-On iOS add an observer to wait for [willEnterForegroundNotification](https://developer.apple.com/documentation/uikit/uiapplication/1622944-willenterforegroundnotification) on the [WKWebView](https://developer.apple.com/documentation/webkit/wkwebview) to call [evaluateJavaScript()](https://developer.apple.com/documentation/webkit/wkwebview/1415017-evaluatejavascript)
-
-
-```swift
-  _ = NotificationCenter.default.addObserver(
-      forName: UIApplication.willEnterForegroundNotification,
-      object: nil,
-      queue: .main
-  ) { (notification: Notification) in
-
-      if UIApplication.shared.applicationState == .background {
-
-          // tell the embedded JS SDK to refresh itself
-          getWebView().evaluateJavaScript("toForeground();") { (result, error) in
-             ...
-          }
-      }
-  }
-```
-
-### Android
-
-On Android register an [ActivityLifecycleCallbacks](https://developer.android.com/reference/android/app/Application.ActivityLifecycleCallbacks) listener and override [onActivityStarted()](https://developer.android.com/reference/android/app/Application.ActivityLifecycleCallbacks#onActivityStarted(android.app.Activity)) (API level 29) then once a foreground event arrives you can call [evaluateJavascript()](https://developer.android.com/reference/android/webkit/WebView#evaluateJavascript(java.lang.String,%20android.webkit.ValueCallback%3Cjava.lang.String%3E)) on the [WebView](https://developer.android.com/reference/android/webkit/WebView)
-
-
-```java
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-      super.onCreate(savedInstanceState);
-
-      registerActivityLifecycleCallbacks(new Application.ActivityLifecycleCallbacks() {
-
-          @Override
-          public void onActivityStarted(@NonNull Activity activity) {
-              WebView webView = findViewById(R.id.webview);
-              // tell the embedded JS SDK to refresh itself
-              webView.evaluateJavascript("toForeground();", (result) -> {
-                  ...
-              });
-          }
-      });
-  }
-```
-
+[Integrating with webviews on mobile devices](mobile_device_support.md)
 
 ## License
 

--- a/examples/preact/package-lock.json
+++ b/examples/preact/package-lock.json
@@ -18,7 +18,7 @@
     },
     "../..": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "license": "Apache-2.0",
       "dependencies": {
         "event-source-polyfill": "1.0.31",

--- a/examples/react-redux/package-lock.json
+++ b/examples/react-redux/package-lock.json
@@ -27,7 +27,7 @@
     },
     "../..": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "license": "Apache-2.0",
       "dependencies": {
         "event-source-polyfill": "1.0.31",

--- a/examples/react/package-lock.json
+++ b/examples/react/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../..": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "license": "Apache-2.0",
       "dependencies": {
         "event-source-polyfill": "1.0.31",

--- a/mobile_device_support.md
+++ b/mobile_device_support.md
@@ -15,9 +15,9 @@ network after enough time has elapsed.
 Once you have a client instance (as shown above) add a function that can be easily invoked from the device's native language
 
 ```typescript
-   function toForeground() {
-      client.refreshEvaluations()
-   }
+  function toForeground() {
+    client.refreshEvaluations()
+  }
 ```
 
 

--- a/mobile_device_support.md
+++ b/mobile_device_support.md
@@ -1,0 +1,69 @@
+## Integration with web views on mobile devices
+
+The SDK can be used inside webviews on native mobile apps for iOS and Android. You will need to add some additional
+code to tell the SDK to update its local evaluations when the app comes to the foreground after being placed into
+the background. This will ensure the SDK has the latest evaluations as the SSE stream will not receive events while
+the app is suspended in the background. Similarly, you may want refresh the SDK if the network comes online after a
+period of no connectivity.
+
+The SDK provides a function on the client instance called `refreshEvaluations`. Calling this allows you to soft poll the
+servers for the latest evaluations. Note to avoid overloading the backend servers this function will only call out to the
+network after enough time has elapsed.
+
+### toForeground JS function
+
+Once you have a client instance (as shown above) add a function that can be easily invoked from the device's native language
+
+```typescript
+   function toForeground() {
+      client.refreshEvaluations()
+   }
+```
+
+
+### iOS
+
+On iOS add an observer to wait for [willEnterForegroundNotification](https://developer.apple.com/documentation/uikit/uiapplication/1622944-willenterforegroundnotification) on the [WKWebView](https://developer.apple.com/documentation/webkit/wkwebview) to call [evaluateJavaScript()](https://developer.apple.com/documentation/webkit/wkwebview/1415017-evaluatejavascript)
+
+
+```swift
+  _ = NotificationCenter.default.addObserver(
+      forName: UIApplication.willEnterForegroundNotification,
+      object: nil,
+      queue: .main
+  ) { (notification: Notification) in
+
+      if UIApplication.shared.applicationState == .background {
+
+          // tell the embedded JS SDK to refresh itself
+          getWebView().evaluateJavaScript("toForeground();") { (result, error) in
+             ...
+          }
+      }
+  }
+```
+
+### Android
+
+On Android register an [ActivityLifecycleCallbacks](https://developer.android.com/reference/android/app/Application.ActivityLifecycleCallbacks) listener and override [onActivityStarted()](https://developer.android.com/reference/android/app/Application.ActivityLifecycleCallbacks#onActivityStarted(android.app.Activity)) (API level 29) then once a foreground event arrives you can call [evaluateJavascript()](https://developer.android.com/reference/android/webkit/WebView#evaluateJavascript(java.lang.String,%20android.webkit.ValueCallback%3Cjava.lang.String%3E)) on the [WebView](https://developer.android.com/reference/android/webkit/WebView)
+
+
+```java
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+      super.onCreate(savedInstanceState);
+
+      registerActivityLifecycleCallbacks(new Application.ActivityLifecycleCallbacks() {
+
+          @Override
+          public void onActivityStarted(@NonNull Activity activity) {
+              WebView webView = findViewById(R.id.webview);
+              // tell the embedded JS SDK to refresh itself
+              webView.evaluateJavascript("toForeground();", (result) -> {
+                  ...
+              });
+          }
+      });
+  }
+```
+

--- a/mobile_device_support.md
+++ b/mobile_device_support.md
@@ -12,7 +12,7 @@ network after enough time has elapsed.
 
 ### toForeground JS function
 
-Once you have a client instance (as shown above) add a function that can be easily invoked from the device's native language
+Once you have a client instance (as shown on the previous page) add a function that can be easily invoked from the device's native language
 
 ```typescript
   function toForeground() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-javascript-client-sdk",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "license": "Apache-2.0",
       "dependencies": {
         "event-source-polyfill": "1.0.31",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-javascript-client-sdk",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "author": "Harness",
   "license": "Apache-2.0",
   "main": "dist/sdk.cjs.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
   let standardHeaders: Record<string, string> = {}
   let fetchWithMiddleware = addMiddlewareToFetch(args => args)
   let eventSourceWithMiddleware = addMiddlewareToEventSource(args => args)
-  let lastCacheRefreshTime: number
+  let lastCacheRefreshTime = 0
 
   const stopMetricsCollector = () => {
     metricsCollectorEnabled = false
@@ -623,19 +623,17 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
     eventSourceWithMiddleware = addMiddlewareToEventSource(middleware)
   }
 
-  const refreshCache = (): boolean => {
+  const refreshEvaluations = (): boolean => {
     // only fetch flags if enough time has elapsed to avoid pressuring backend servers
-    if (!lastCacheRefreshTime || Math.round((Date.now() - lastCacheRefreshTime) / 1000) >== 60) {
+    if (Date.now() - lastCacheRefreshTime >= 60000) {
       fetchFlags()
       lastCacheRefreshTime = Date.now()
       return true
     }
-
-    logDebug('Refresh cache skipped. Not enough time has elapsed since last call')
     return false
   }
 
-  return { on, off, variation, close, setEvaluations, registerAPIRequestMiddleware, refreshCache }
+  return { on, off, variation, close, setEvaluations, registerAPIRequestMiddleware, refreshEvaluations }
 }
 
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
   let standardHeaders: Record<string, string> = {}
   let fetchWithMiddleware = addMiddlewareToFetch(args => args)
   let eventSourceWithMiddleware = addMiddlewareToEventSource(args => args)
-  let lastCacheRefreshTime = null
+  let lastCacheRefreshTime: number
 
   const stopMetricsCollector = () => {
     metricsCollectorEnabled = false

--- a/src/index.ts
+++ b/src/index.ts
@@ -625,7 +625,7 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
 
   const refreshCache = (): boolean => {
     // only fetch flags if enough time has elapsed to avoid pressuring backend servers
-    if (lastCacheRefreshTime == null || Math.round((Date.now()-lastCacheRefreshTime)/1000) >= 60) {
+    if (!lastCacheRefreshTime || Math.round((Date.now() - lastCacheRefreshTime) / 1000) >== 60) {
       fetchFlags()
       lastCacheRefreshTime = Date.now()
       return true

--- a/src/index.ts
+++ b/src/index.ts
@@ -623,14 +623,12 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
     eventSourceWithMiddleware = addMiddlewareToEventSource(middleware)
   }
 
-  const refreshEvaluations = (): boolean => {
+  const refreshEvaluations = () => {
     // only fetch flags if enough time has elapsed to avoid pressuring backend servers
     if (Date.now() - lastCacheRefreshTime >= 60000) {
       fetchFlags()
       lastCacheRefreshTime = Date.now()
-      return true
     }
-    return false
   }
 
   return { on, off, variation, close, setEvaluations, registerAPIRequestMiddleware, refreshEvaluations }

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,7 @@ export interface Result {
   close: () => void
   setEvaluations: (evaluations: Evaluation[]) => void
   registerAPIRequestMiddleware: (middleware: APIRequestMiddleware) => void
+  refreshCache: () => boolean
 }
 
 type FetchArgs = Parameters<typeof fetch>

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,7 +66,7 @@ export interface Result {
   close: () => void
   setEvaluations: (evaluations: Evaluation[]) => void
   registerAPIRequestMiddleware: (middleware: APIRequestMiddleware) => void
-  refreshEvaluations: () => boolean
+  refreshEvaluations: () => void
 }
 
 type FetchArgs = Parameters<typeof fetch>

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,7 +66,7 @@ export interface Result {
   close: () => void
   setEvaluations: (evaluations: Evaluation[]) => void
   registerAPIRequestMiddleware: (middleware: APIRequestMiddleware) => void
-  refreshCache: () => boolean
+  refreshEvaluations: () => boolean
 }
 
 type FetchArgs = Parameters<typeof fetch>


### PR DESCRIPTION
FFM-8141 - Add refreshEvaluations() API method to allow webviews inside mobile apps coming to foreground to get latest flags

What
Adds a new function called refreshEvaluations() to CfClient

Why
This change adds a new API called refreshEvaluations() which can be called by a mobile app using the SDK in a webview coming to the foreground to update any SSE flag events that were missed while the app was suspended. Note this new API should not be used to poll the Feature Flags server, it will only retrieve evaluations from the server if enough time has elapsed to avoid putting to much pressure on the backend.

It's up to the native app to call this JS method from the webview APIs when the app comes to foreground.

Testing
Manual. Tested with Xcode + iOS Simulator with a WKWebView