### PR TITLE
FFM-8963 Add new `enhancedVariation` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,22 @@ client.on(Event.ERROR_STREAM, error => {
 
 ### Getting value for a particular feature flag
 
+If you would like to know that the default variation was returned when getting the value, for example, if the provided flag identifier wasn't found:
+
+```typescript
+const result = client.enhancedVariation('Dark_Theme', false) // second argument is default value when variation does not exist
+switch (result.type) {
+  case 'success':
+    return result.value
+  case 'error':
+    // Log the error and return the default variation
+    console.error(result.message);
+    return result.defaultValue
+}
+```
+
+If you do not need to know that
+
 ```typescript
 const value = client.variation('Dark_Theme', false) // second argument is default value when variation does not exist
 ```

--- a/README.md
+++ b/README.md
@@ -137,10 +137,10 @@ switch (result.type) {
 }
 ```
 
-If you do not need to know that
+If you do not need to know the default variation was returned: 
 
 ```typescript
-const value = client.variation('Dark_Theme', false) // second argument is default value when variation does not exist
+const variationValue = client.variation('Dark_Theme', false) // second argument is default value when variation does not exist
 ```
 
 ### Cleaning up

--- a/src/__tests__/variation.test.ts
+++ b/src/__tests__/variation.test.ts
@@ -2,7 +2,7 @@ import { variation, enhancedVariation } from '../variation'; // Modify the impor
 
 describe('variation', () => {
     it('should return the stored value when it exists', () => {
-        const storage = { testFlag: true };
+        const storage = { testFlag: true, otherFlag: true, anotherFlag: false };
         const mockMetricsHandler = jest.fn();
 
         const result = variation(storage, 'testFlag', false, mockMetricsHandler);
@@ -23,11 +23,12 @@ describe('variation', () => {
 });
 
 describe('enhancedVariation', () => {
+    const flagIdentifier = 'testFlag';
     it('should return success type with the stored value when it exists', () => {
-        const storage = { testFlag: true };
+        const storage = { testFlag: true, otherFlag: true, anotherFlag: false };
         const mockMetricsHandler = jest.fn();
 
-        const result = enhancedVariation(storage, 'testFlag', false, mockMetricsHandler);
+        const result = enhancedVariation(storage, flagIdentifier, false, mockMetricsHandler);
 
         expect(result.type).toBe('success');
 
@@ -35,15 +36,15 @@ describe('enhancedVariation', () => {
             expect(result.value).toBe(true);
         }
 
-        expect(mockMetricsHandler).toBeCalledWith('testFlag', true);
+        expect(mockMetricsHandler).toBeCalledWith(flagIdentifier, true);
     });
 
 
     it('should return error type with default value when flag is missing', () => {
-        const storage = {};
+        const storage = {otherFlag: true};
         const mockMetricsHandler = jest.fn();
 
-        const result = enhancedVariation(storage, 'testFlag', false, mockMetricsHandler);
+        const result = enhancedVariation(storage, flagIdentifier, false, mockMetricsHandler);
 
         expect(result.type).toBe('error');
         if (result.type === 'error') {
@@ -54,10 +55,10 @@ describe('enhancedVariation', () => {
     });
 
     it('should return error type with default value when stored value is undefined', () => {
-        const storage = { testFlag: undefined };
+        const storage = { testFlag: undefined, otherFlag: true, anotherFlag: false };
         const mockMetricsHandler = jest.fn();
 
-        const result = enhancedVariation(storage, 'testFlag', false, mockMetricsHandler);
+        const result = enhancedVariation(storage, flagIdentifier, false, mockMetricsHandler);
 
         expect(result.type).toBe('error');
         if (result.type === 'error') {

--- a/src/__tests__/variation.test.ts
+++ b/src/__tests__/variation.test.ts
@@ -1,0 +1,69 @@
+import { variation, enhancedVariation } from '../variation'; // Modify the import based on your file structure.
+
+describe('variation', () => {
+    it('should return the stored value when it exists', () => {
+        const storage = { testFlag: true };
+        const mockMetricsHandler = jest.fn();
+
+        const result = variation(storage, 'testFlag', false, mockMetricsHandler);
+
+        expect(result).toBe(true);
+        expect(mockMetricsHandler).toBeCalledWith('testFlag', true);
+    });
+
+    it('should return the default value when stored value is undefined', () => {
+        const storage = {};
+        const mockMetricsHandler = jest.fn();
+
+        const result = variation(storage, 'testFlag', false, mockMetricsHandler);
+
+        expect(result).toBe(false);
+        expect(mockMetricsHandler).toBeCalledWith('testFlag', undefined);
+    });
+});
+
+describe('enhancedVariation', () => {
+    it('should return success type with the stored value when it exists', () => {
+        const storage = { testFlag: true };
+        const mockMetricsHandler = jest.fn();
+
+        const result = enhancedVariation(storage, 'testFlag', false, mockMetricsHandler);
+
+        expect(result.type).toBe('success');
+
+        if (result.type === 'success') {
+            expect(result.value).toBe(true);
+        }
+
+        expect(mockMetricsHandler).toBeCalledWith('testFlag', true);
+    });
+
+
+    it('should return error type with default value when flag is missing', () => {
+        const storage = {};
+        const mockMetricsHandler = jest.fn();
+
+        const result = enhancedVariation(storage, 'testFlag', false, mockMetricsHandler);
+
+        expect(result.type).toBe('error');
+        if (result.type === 'error') {
+            expect(result.defaultValue).toBe(false);
+            expect(result.message).toBe('The flag "testFlag" does not exist in storage.');
+        }
+
+    });
+
+    it('should return error type with default value when stored value is undefined', () => {
+        const storage = { testFlag: undefined };
+        const mockMetricsHandler = jest.fn();
+
+        const result = enhancedVariation(storage, 'testFlag', false, mockMetricsHandler);
+
+        expect(result.type).toBe('error');
+        if (result.type === 'error') {
+            expect(result.defaultValue).toBe(false);
+            expect(result.message).toBe('The variation value for flag "testFlag" is undefined. Returning default value.');
+        }
+
+    });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -532,7 +532,7 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
       return {
         type: 'error',
         defaultValue,
-        message: `The value for flag "${flagIdentifier}" is undefined. Returning default value.`
+        message: `The variation value for flag "${flagIdentifier}" is undefined. Returning default value.`
       };
     }
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -533,9 +533,6 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
         type: 'error',
         defaultValue,
         message: `The value for flag "${flagIdentifier}" is undefined. Returning default value.`
-        // Note: Since you're using discriminated unions with clear success/error types,
-        // you don't provide the default value in the error result. If you wanted to provide it,
-        // you'd need to adjust your type definitions.
       };
     }
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -512,18 +512,33 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
 
   const enhancedVariation = (flagIdentifier: string, defaultValue: any): EnhancedVariationResult => {
     if (!flagExists(flagIdentifier)) {
-      return { value: defaultValue, status: 'error', message: `The flag "${flagIdentifier}" does not exist in storage.` };
+      return {
+        type: 'error',
+        defaultValue,
+        message: `The flag "${flagIdentifier}" does not exist in storage.`
+      };
     }
 
     const value = storage[flagIdentifier];
     handleMetrics(flagIdentifier, value);
 
-    return {
-      value: value !== undefined ? value : defaultValue,
-      status: value !== undefined ? 'success' : 'error',
-      message: value !== undefined ? undefined : `The value for flag "${flagIdentifier}" is undefined. Returning default value.`
-    };
+    if (value !== undefined) {
+      return {
+        type: 'success',
+        value
+      };
+    } else {
+      return {
+        type: 'error',
+        defaultValue,
+        message: `The value for flag "${flagIdentifier}" is undefined. Returning default value.`
+        // Note: Since you're using discriminated unions with clear success/error types,
+        // you don't provide the default value in the error result. If you wanted to provide it,
+        // you'd need to adjust your type definitions.
+      };
+    }
   };
+
 
   const flagExists = (flag: string): boolean => {
     return storage.hasOwnProperty(flag);

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,8 @@ import type {
   Options,
   Result,
   StreamEvent,
-  Target, EnhancedVariationResult,
+  Target,
+  EnhancedVariationResult,
   VariationValue
 } from './types'
 import { Event } from './types'

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,14 @@ export enum Event {
 
 export type VariationValue = boolean | string | number | object | undefined
 
+// Used when callers, such as the Flutter SDK for Web, require to know if the variation failed
+// and the default value was returned.
+export type EnhancedVariationResult = {
+  value: VariationValue;
+  status: 'success' | 'error';
+  message?: string;
+};
+
 export interface Evaluation {
   flag: string // Feature flag identifier
   identifier: string // variation identifier
@@ -67,6 +75,7 @@ export interface Result {
   setEvaluations: (evaluations: Evaluation[]) => void
   registerAPIRequestMiddleware: (middleware: APIRequestMiddleware) => void
   refreshEvaluations: () => void
+  enhancedVariation: (flagIdentifier: string, defaultValue: string) => EnhancedVariationResult
 }
 
 type FetchArgs = Parameters<typeof fetch>

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,11 +32,18 @@ export type VariationValue = boolean | string | number | object | undefined
 
 // Used when callers, such as the Flutter SDK for Web, require to know if the variation failed
 // and the default value was returned.
-export type EnhancedVariationResult = {
+type EnhancedVariationSuccess = {
+  type: 'success';
   value: VariationValue;
-  status: 'success' | 'error';
-  message?: string;
 };
+
+type EnhancedVariationError = {
+  type: 'error';
+  defaultValue: VariationValue
+  message: string;
+};
+
+export type EnhancedVariationResult = EnhancedVariationSuccess | EnhancedVariationError;
 
 export interface Evaluation {
   flag: string // Feature flag identifier

--- a/src/variation.ts
+++ b/src/variation.ts
@@ -1,0 +1,47 @@
+import type { EnhancedVariationResult, VariationValue } from './types'
+
+export function variation(
+  storage: Record<string, any>,
+  flag: string,
+  defaultValue: any,
+  metricsHandler: (flag: string, value: any) => void
+): VariationValue {
+  const value = storage[flag]
+    metricsHandler(flag, value)
+  return value !== undefined ? value : defaultValue
+}
+
+export function enhancedVariation(
+  storage: Record<string, any>,
+  flagIdentifier: string,
+  defaultValue: any,
+  metricsHandler: (flag: string, value: any) => void
+): EnhancedVariationResult {
+  if (!flagExists(storage, flagIdentifier)) {
+    return {
+      type: 'error',
+      defaultValue,
+      message: `The flag "${flagIdentifier}" does not exist in storage.`
+    }
+  }
+
+  const value = storage[flagIdentifier]
+  metricsHandler(flagIdentifier, value)
+
+  if (value !== undefined) {
+    return {
+      type: 'success',
+      value
+    }
+  } else {
+    return {
+      type: 'error',
+      defaultValue,
+      message: `The variation value for flag "${flagIdentifier}" is undefined. Returning default value.`
+    }
+  }
+}
+
+const flagExists = (storage: Record<string, any>, flag: string): boolean => {
+  return storage.hasOwnProperty(flag)
+}


### PR DESCRIPTION
# What
The existing `variation` function does not provide any indication that the default variation was returned. This is not suitable for the Flutter Web plugin, which needs to provide a consistent experience across Android/iOS and Web. The Web Plugin needs to know if the default variation was returned, so that the user can be informed and take appropriate action.

To keep backwards compatability, instead of refactoring the `variation` function and enabling a new code path with an SDK option, this adds a new function to the SDK called `enhancedVariation` which lets users know if the function returned the default variation.

Also extracted metrics handling into its own function so both original and new variation functions can post metrics without code duplication.

# Testing - Manual

Original variation function: 

1. Still returns cached variation or default variation if flag does not exist.
2. Still posts metrics successfully  

New Enhanced variation function:
1. Returns the correct object based on if the flag exists or not. 
2. Post metrics correctly. 
