### PR TITLE
FFM-8964 - Stop hearbeat monitor when `close()` is called

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,7 @@ client.on(Event.DISCONNECTED, () => {
 })
 
 client.on(Event.CONNECTED, () => {
-  // Event happens when connection established
-})
-
-client.on(Event.RESUMED, () => {
-  // Event happens when a connection has disconnected but then reconnected
+  // Event happens when connection has been lost and reestablished 
 })
 
 client.on(Event.POLLING, () => {

--- a/README.md
+++ b/README.md
@@ -144,6 +144,22 @@ client.on(Event.DISCONNECTED, () => {
   // Event happens when connection is disconnected
 })
 
+client.on(Event.CONNECTED, () => {
+  // Event happens when connection established
+})
+
+client.on(Event.RESUMED, () => {
+  // Event happens when a connection has disconnected but then reconnected
+})
+
+client.on(Event.POLLING, () => {
+  // Event happens when polling begins
+})
+
+client.on(Event.POLLING_STOPPED, () => {
+  // Event happens when polling stops
+})
+
 client.on(Event.ERROR, error => {
   // Event happens when connection some error has occurred
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-javascript-client-sdk",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.17.0",
+      "version": "1.17.1",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-javascript-client-sdk",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "author": "Harness",
   "license": "Apache-2.0",
   "main": "dist/sdk.cjs.js",

--- a/src/__tests__/poller.test.ts
+++ b/src/__tests__/poller.test.ts
@@ -1,7 +1,7 @@
 import Poller from '../poller'
 import type { Options } from '../types'
 import { getRandom } from '../utils'
-import {Event} from "../types";
+import { Event } from '../types'
 
 jest.useFakeTimers()
 
@@ -12,11 +12,11 @@ jest.mock('../utils.ts', () => ({
 
 const mockEventBus = {
   emit: jest.fn()
-};
+}
 
 interface PollerArgs {
-  fetchFlags: jest.MockedFunction<() => Promise<any>>,
-  eventBus:  typeof mockEventBus,
+  fetchFlags: jest.MockedFunction<() => Promise<any>>
+  eventBus: typeof mockEventBus
   configurations: Partial<Options>
 }
 
@@ -66,7 +66,7 @@ describe('Poller', () => {
     currentPoller.start()
     expect(testArgs.logSpy).toHaveBeenCalledTimes(2)
 
-    expect(mockEventBus.emit).toHaveBeenCalled();
+    expect(mockEventBus.emit).toHaveBeenCalled()
   })
 
   it('should retry fetching if there is an error', async () => {
@@ -145,7 +145,7 @@ describe('Poller', () => {
     const pollInterval = 60000
     const fetchFlagsMock = jest.fn().mockResolvedValue(null)
 
-     getPoller({
+    getPoller({
       fetchFlags: fetchFlagsMock,
       configurations: { pollingInterval: pollInterval, debug: true }
     })
@@ -187,6 +187,5 @@ describe('Poller', () => {
     jest.advanceTimersByTime(pollInterval)
 
     expect(fetchFlagsMock).not.toHaveBeenCalled()
-
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -426,7 +426,7 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
   }
 
   // We instantiate the Poller here so it can be used as a fallback for streaming, but we don't start it yet.
-  poller = new Poller(fetchFlags, configurations)
+  poller = new Poller(fetchFlags, configurations, eventBus)
 
   const startStream = () => {
     const handleFlagEvent = (event: StreamEvent): void => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -544,7 +544,6 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
   const close = () => {
     closed = true
     if (configurations.streamEnabled) {
-
       logDebug('Closing event stream')
 
       if (typeof eventSource?.close === 'function') {

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -1,5 +1,6 @@
 import type { Options } from './types'
 import { getRandom, logError } from './utils'
+import {Event} from "./types";
 
 export default class Poller {
   private timeoutId: any
@@ -9,6 +10,7 @@ export default class Poller {
   constructor(
     private fetchFlagsFn: () => Promise<any>,
     private configurations: Options,
+    private eventBus: any
   ) {}
 
   public start(): void {
@@ -18,6 +20,7 @@ export default class Poller {
     }
 
     this.isRunning = true
+    this.eventBus.emit(Event.POLLING)
 
     this.logDebug(`Starting poller, first poll will be in ${this.configurations.pollingInterval}ms`)
     // Don't start polling immediately as we have already fetched flags on client initialization
@@ -60,6 +63,7 @@ export default class Poller {
       clearTimeout(this.timeoutId)
       this.timeoutId = undefined
       this.isRunning = false
+      this.eventBus.emit(Event.POLLING_STOPPED)
       this.logDebug("Polling stopped")
     }
   }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -15,6 +15,7 @@ export class Streamer {
   private closed: boolean = false
   private readTimeoutCheckerId: any
   private fallbackPoller: Poller
+  private streamDisconnected: boolean
 
   constructor(eventBus, configurations, url, apiKey, standardHeaders, fallbackPoller, eventCallback) {
     this.eventBus = eventBus
@@ -42,9 +43,14 @@ export class Streamer {
     const onConnected = () => {
       this.logDebug('Stream connected')
       this.eventBus.emit(Event.CONNECTED)
+      if (this.streamDisconnected) {
+        this.eventBus.emit(Event.RESUMED)
+        this.streamDisconnected = false
+      }
     }
 
     const onDisconnect = () => {
+      this.streamDisconnected = true
       clearInterval(this.readTimeoutCheckerId)
       const reconnectDelayMs = getRandom(1000, 10000)
       this.logDebug('Stream disconnected, will reconnect in ' + reconnectDelayMs + 'ms')
@@ -97,7 +103,6 @@ export class Streamer {
         onFailed(`HTTP code ${this.xhr.status}`)
         return
       }
-
 
       onConnected()
     }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -15,7 +15,6 @@ export class Streamer {
   private closed: boolean = false
   private readTimeoutCheckerId: any
   private fallbackPoller: Poller
-  private streamDisconnected: boolean
 
   constructor(eventBus, configurations, url, apiKey, standardHeaders, fallbackPoller, eventCallback) {
     this.eventBus = eventBus
@@ -43,14 +42,9 @@ export class Streamer {
     const onConnected = () => {
       this.logDebug('Stream connected')
       this.eventBus.emit(Event.CONNECTED)
-      if (this.streamDisconnected) {
-        this.eventBus.emit(Event.RESUMED)
-        this.streamDisconnected = false
-      }
     }
 
     const onDisconnect = () => {
-      this.streamDisconnected = true
       clearInterval(this.readTimeoutCheckerId)
       const reconnectDelayMs = getRandom(1000, 10000)
       this.logDebug('Stream disconnected, will reconnect in ' + reconnectDelayMs + 'ms')

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,6 @@ export interface StreamEvent {
 export enum Event {
   READY = 'ready',
   CONNECTED = 'connected',
-  RESUMED = 'resumed',
   DISCONNECTED = 'disconnected',
   POLLING = 'polling',
   POLLING_STOPPED = 'polling stopped',
@@ -51,6 +50,8 @@ export interface Evaluation {
 export interface EventCallbackMapping {
   [Event.READY]: (flags: Record<string, VariationValue>) => void
   [Event.CONNECTED]: () => void
+  [Event.POLLING]: () => void
+  [Event.POLLING_STOPPED]: () => void
   [Event.DISCONNECTED]: () => void
   [Event.FLAGS_LOADED]: (evaluations: Evaluation[]) => void
   [Event.CACHE_LOADED]: (evaluations: Evaluation[]) => void

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,8 @@ export enum Event {
   CONNECTED = 'connected',
   RESUMED = 'resumed',
   DISCONNECTED = 'disconnected',
+  POLLING = 'polling',
+  POLLING_STOPPED = 'polling stopped',
   FLAGS_LOADED = 'flags loaded',
   CACHE_LOADED = 'cache loaded',
   CHANGED = 'changed',

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export interface StreamEvent {
 export enum Event {
   READY = 'ready',
   CONNECTED = 'connected',
+  RESUMED = 'resumed',
   DISCONNECTED = 'disconnected',
   FLAGS_LOADED = 'flags loaded',
   CACHE_LOADED = 'cache loaded',


### PR DESCRIPTION
# What
When `close()` is called, the heartbeat monitor still runs and logs an error that the SSE connection times out. This update clears that heartbeat monitor interval when close is ran. 

Also adds polling events

# Why
So we don't log timeout errors when the stream is closed 

# Testing
Manual