### PR TITLE
FFM-9045 Emit flags as part of polling intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ client.on(Event.CACHE_LOADED, evaluations => {
 
 client.on(Event.CHANGED, flagInfo => {
   // Event happens when a changed event is pushed
-  // flagInfo contains information about the updated feature flag
+  // flagInfo contains the updated feature flag
 })
 
 client.on(Event.DISCONNECTED, () => {
@@ -150,6 +150,11 @@ client.on(Event.CONNECTED, () => {
 
 client.on(Event.POLLING, () => {
   // Event happens when polling begins
+})
+
+client.on(Event.POLLING_CHANGED, flagInfo => {
+  // Event happens when SDK polls for flags
+  // flagInfo contains the polled feature flags
 })
 
 client.on(Event.POLLING_STOPPED, () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-javascript-client-sdk",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.17.1",
+      "version": "1.18.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-javascript-client-sdk",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "author": "Harness",
   "license": "Apache-2.0",
   "main": "dist/sdk.cjs.js",

--- a/src/__tests__/poller.test.ts
+++ b/src/__tests__/poller.test.ts
@@ -201,7 +201,6 @@ describe('Poller', () => {
     // Use this just to mock the calls to console.debug
     getTestArgs()
 
-
     // Start the poller
     currentPoller.start()
 

--- a/src/__tests__/poller.test.ts
+++ b/src/__tests__/poller.test.ts
@@ -57,8 +57,8 @@ const getTestArgs = (overrides: Partial<TestArgs> = {}): TestArgs => {
 
 describe('Poller', () => {
   afterEach(() => {
+    currentPoller.stop()
     jest.clearAllMocks()
-    currentPoller?.stop()
   })
   it('should not start polling if it is already polling', () => {
     getPoller({ configurations: { debug: true } })

--- a/src/__tests__/poller.test.ts
+++ b/src/__tests__/poller.test.ts
@@ -198,6 +198,10 @@ describe('Poller', () => {
       configurations: { pollingInterval: pollInterval, debug: true }
     })
 
+    // Use this just to mock the calls to console.debug
+    getTestArgs()
+
+
     // Start the poller
     currentPoller.start()
 
@@ -210,10 +214,10 @@ describe('Poller', () => {
     // Now we'll check that eventBus.emit was called with POLLING_STOPPED.
     expect(mockEventBus.emit).toHaveBeenCalledWith(Event.POLLING_STOPPED)
 
-    // Ensure the debug message for polling stopped is logged.
+    // Ensure that fetchFlags isn't called after the poller has been stopped
     expect(fetchFlagsMock).not.toHaveBeenCalled()
 
-    // Advance timers to ensure that the poller doesn't actually poll after being stopped.
+    // As a final check, advance timers to ensure that the poller doesn't poll after an elapsed interval.
     jest.advanceTimersByTime(pollInterval)
 
     expect(fetchFlagsMock).not.toHaveBeenCalled()

--- a/src/__tests__/poller.test.ts
+++ b/src/__tests__/poller.test.ts
@@ -78,7 +78,6 @@ describe('Poller', () => {
       .mockImplementation((): Promise<FetchFlagsResult> => {
         attemptCount++
 
-        // Return null (success) on the maxAttempts-th call, error otherwise.
         return Promise.resolve(
           attemptCount === 2
             ? {

--- a/src/__tests__/poller.test.ts
+++ b/src/__tests__/poller.test.ts
@@ -121,9 +121,6 @@ describe('Poller', () => {
       .mockImplementation((): Promise<FetchFlagsResult> => {
         attemptCount++
 
-        // Return null (success) on the maxAttempts-th call, error otherwise.
-        // return Promise.resolve(attemptCount === maxAttempts ? null : mockError)
-
         return Promise.resolve(
           attemptCount === maxAttempts
             ? {
@@ -163,9 +160,6 @@ describe('Poller', () => {
     const fetchFlagsMock: jest.Mock<Promise<FetchFlagsResult>> = jest
       .fn()
       .mockImplementation((): Promise<FetchFlagsResult> => {
-        // Return null (success) on the maxAttempts-th call, error otherwise.
-        // return Promise.resolve(attemptCount === maxAttempts ? null : mockError)
-
         return Promise.resolve({
           type: 'success',
           data: [{ flag: 'flag1', kind: 'boolean', value: true, identifier: 'true' }]

--- a/src/__tests__/poller.test.ts
+++ b/src/__tests__/poller.test.ts
@@ -17,7 +17,6 @@ const mockEventBus = {
 interface PollerArgs {
   fetchFlags: jest.MockedFunction<() => Promise<FetchFlagsResult>>
   eventBus: typeof mockEventBus
-  storage: Record<string, any>
   configurations: Partial<Options>
 }
 
@@ -34,11 +33,10 @@ const getPoller = (overrides: Partial<PollerArgs> = {}): Poller => {
     fetchFlags: jest.fn(),
     configurations: {},
     eventBus: mockEventBus,
-    storage: {},
     ...overrides
   }
 
-  currentPoller = new Poller(args.fetchFlags, args.configurations, args.eventBus, args.storage)
+  currentPoller = new Poller(args.fetchFlags, args.configurations, args.eventBus)
 
   return currentPoller
 }

--- a/src/__tests__/poller.test.ts
+++ b/src/__tests__/poller.test.ts
@@ -16,7 +16,8 @@ const mockEventBus = {
 
 interface PollerArgs {
   fetchFlags: jest.MockedFunction<() => Promise<any>>
-  eventBus: typeof mockEventBus
+  eventBus: typeof mockEventBus,
+  storage: Record<string, any>
   configurations: Partial<Options>
 }
 
@@ -33,10 +34,11 @@ const getPoller = (overrides: Partial<PollerArgs> = {}): Poller => {
     fetchFlags: jest.fn(),
     configurations: {},
     eventBus: mockEventBus,
+    storage: {},
     ...overrides
   }
 
-  currentPoller = new Poller(args.fetchFlags, args.configurations, args.eventBus)
+  currentPoller = new Poller(args.fetchFlags, args.configurations, args.eventBus, args.storage)
 
   return currentPoller
 }

--- a/src/__tests__/poller.test.ts
+++ b/src/__tests__/poller.test.ts
@@ -110,7 +110,7 @@ describe('Poller', () => {
     await Promise.resolve()
 
     expect(fetchFlagsMock).toHaveBeenCalledTimes(2)
-    expect(testArgs.logSpy).toHaveBeenCalledTimes(3)
+    expect(testArgs.logSpy).toHaveBeenCalledTimes(2)
   })
 
   it('should not retry after max attempts are exceeded', async () => {

--- a/src/__tests__/poller.test.ts
+++ b/src/__tests__/poller.test.ts
@@ -1,5 +1,5 @@
 import Poller from '../poller'
-import type { Options } from '../types'
+import type { FetchFlagsResult, Options } from '../types'
 import { getRandom } from '../utils'
 import { Event } from '../types'
 
@@ -15,8 +15,8 @@ const mockEventBus = {
 }
 
 interface PollerArgs {
-  fetchFlags: jest.MockedFunction<() => Promise<any>>
-  eventBus: typeof mockEventBus,
+  fetchFlags: jest.MockedFunction<() => Promise<FetchFlagsResult>>
+  eventBus: typeof mockEventBus
   storage: Record<string, any>
   configurations: Partial<Options>
 }
@@ -75,11 +75,18 @@ describe('Poller', () => {
     const testArgs = getTestArgs()
 
     let attemptCount = 0
-    const fetchFlagsMock = jest.fn().mockImplementation(() => {
+    const fetchFlagsMock: jest.Mock<Promise<FetchFlagsResult>> = jest.fn().mockImplementation((): Promise<FetchFlagsResult> => {
       attemptCount++
 
       // Return null (success) on the maxAttempts-th call, error otherwise.
-      return Promise.resolve(attemptCount === 2 ? null : testArgs.mockError)
+      return Promise.resolve(
+        attemptCount === 2
+          ? ({
+              type: 'success',
+              data: [{ flag: 'flag1', kind: 'boolean', value: true, identifier: 'true' }]
+            }  )
+          : { type: 'error', error: testArgs.mockError } as FetchFlagsResult
+      )
     })
 
     const pollInterval = 60000

--- a/src/index.ts
+++ b/src/index.ts
@@ -426,7 +426,7 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
   }
 
   // We instantiate the Poller here so it can be used as a fallback for streaming, but we don't start it yet.
-  poller = new Poller(fetchFlags, configurations, eventBus)
+  poller = new Poller(fetchFlags, configurations, eventBus, storage)
 
   const startStream = () => {
     const handleFlagEvent = (event: StreamEvent): void => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -429,7 +429,7 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
   }
 
   // We instantiate the Poller here so it can be used as a fallback for streaming, but we don't start it yet.
-  poller = new Poller(fetchFlags, configurations, eventBus, storage)
+  poller = new Poller(fetchFlags, configurations, eventBus)
 
   const startStream = () => {
     const handleFlagEvent = (event: StreamEvent): void => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -329,7 +329,7 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
       // When authentication is done, fetch all flags
       const fetchFlagsResult = await fetchFlags()
 
-      if (fetchFlagsResult.type === "success") {
+      if (fetchFlagsResult.type === 'success') {
         logDebug('Fetch all flags ok', storage)
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -327,9 +327,9 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
       const hasExistingFlags = !!Object.keys(evaluations).length
 
       // When authentication is done, fetch all flags
-      const error = await fetchFlags()
+      const fetchFlagsResult = await fetchFlags()
 
-      if (!error) {
+      if (fetchFlagsResult.type === "success") {
         logDebug('Fetch all flags ok', storage)
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import type {
   Evaluation,
   EventOffBinding,
   EventOnBinding,
+  FetchFlagsResult,
   MetricsInfo,
   Options,
   Result,
@@ -360,7 +361,7 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
       eventBus.emit(Event.ERROR, error)
     })
 
-  const fetchFlags = async () => {
+  const fetchFlags = async (): Promise<FetchFlagsResult> => {
     try {
       const res = await fetchWithMiddleware(
         `${configurations.baseUrl}/client/env/${environment}/target/${target.identifier}/evaluations?cluster=${clusterIdentifier}`,
@@ -373,16 +374,18 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
         const data = await res.json()
         data.forEach(registerEvaluation)
         eventBus.emit(Event.FLAGS_LOADED, data)
+        return { type: 'success', data: data }
       } else {
         logError('Features fetch operation error: ', res)
         eventBus.emit(Event.ERROR_FETCH_FLAGS, res)
         eventBus.emit(Event.ERROR, res)
+        return { type: 'error', error: res }
       }
     } catch (error) {
       logError('Features fetch operation error: ', error)
       eventBus.emit(Event.ERROR_FETCH_FLAGS, error)
       eventBus.emit(Event.ERROR, error)
-      return error
+      return { type: 'error', error: error }
     }
   }
 

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -25,8 +25,8 @@ export default class Poller {
     this.eventBus.emit(Event.POLLING)
 
     this.logDebug(`Starting poller, first poll will be in ${this.configurations.pollingInterval}ms`)
+
     // Don't start polling immediately as we have already fetched flags on client initialization
-    // TODO UNCOMMENT THIS!!!!!!!!
     this.timeoutId = setTimeout(() => this.poll(), this.configurations.pollingInterval)
   }
 

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -26,7 +26,8 @@ export default class Poller {
 
     this.logDebug(`Starting poller, first poll will be in ${this.configurations.pollingInterval}ms`)
     // Don't start polling immediately as we have already fetched flags on client initialization
-    // this.timeoutId = setTimeout(() => this.poll(), this.configurations.pollingInterval)
+    // TODO UNCOMMENT THIS!!!!!!!!
+    this.timeoutId = setTimeout(() => this.poll(), this.configurations.pollingInterval)
     this.poll()
   }
 

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -26,7 +26,8 @@ export default class Poller {
 
     this.logDebug(`Starting poller, first poll will be in ${this.configurations.pollingInterval}ms`)
     // Don't start polling immediately as we have already fetched flags on client initialization
-    this.timeoutId = setTimeout(() => this.poll(), this.configurations.pollingInterval)
+    // this.timeoutId = setTimeout(() => this.poll(), this.configurations.pollingInterval)
+    this.poll()
   }
 
   private poll(): void {

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -42,7 +42,7 @@ export default class Poller {
 
       if (result.type === 'success') {
         this.logDebug(`Successfully polled for flag updates, next poll in ${this.configurations.pollingInterval}ms. `)
-        this.eventBus.emit(Event.POLLING_CHANGED, this.storage)
+        this.eventBus.emit(Event.POLLING_CHANGED, result.data)
         return
       }
 

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -1,6 +1,6 @@
 import type { Options } from './types'
 import { getRandom, logError } from './utils'
-import {Event, FetchFlagsResult} from './types'
+import { Event, FetchFlagsResult } from './types'
 
 export default class Poller {
   private timeoutId: any
@@ -10,10 +10,9 @@ export default class Poller {
   constructor(
     private fetchFlagsFn: () => Promise<FetchFlagsResult>,
     private configurations: Options,
-    private eventBus: any,
-    // Used to emit the updates retrieved in polling intervals
-    private storage: Record<string, any>
-  ) {}
+    private eventBus: any
+  ) // Used to emit the updates retrieved in polling intervals
+  {}
 
   public start(): void {
     if (this.isPolling()) {

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -1,6 +1,6 @@
 import type { Options } from './types'
 import { getRandom, logError } from './utils'
-import { Event } from './types'
+import {Event, FetchFlagsResult} from './types'
 
 export default class Poller {
   private timeoutId: any
@@ -8,7 +8,7 @@ export default class Poller {
   private maxAttempts = 5
 
   constructor(
-    private fetchFlagsFn: () => Promise<any>,
+    private fetchFlagsFn: () => Promise<FetchFlagsResult>,
     private configurations: Options,
     private eventBus: any,
     // Used to emit the updates retrieved in polling intervals
@@ -38,15 +38,15 @@ export default class Poller {
 
   private async attemptFetch(): Promise<void> {
     for (let attempt = 1; attempt <= this.maxAttempts; attempt++) {
-      const error = await this.fetchFlagsFn()
+      const result = await this.fetchFlagsFn()
 
-      if (!error) {
+      if (result.type === 'success') {
         this.logDebug(`Successfully polled for flag updates, next poll in ${this.configurations.pollingInterval}ms. `)
         this.eventBus.emit(Event.POLLING_CHANGED, this.storage)
         return
       }
 
-      logError('Error when polling for flag updates', error)
+      logError('Error when polling for flag updates', result.error)
 
       // Retry fetching flags
       if (attempt >= this.maxAttempts) {
@@ -58,7 +58,7 @@ export default class Poller {
 
       this.logDebug(
         `Polling for flags attempt #${attempt} failed. Remaining attempts: ${this.maxAttempts - attempt}`,
-        error
+        result.error
       )
 
       const delay = getRandom(1000, 10000)

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -41,7 +41,7 @@ export default class Poller {
 
       if (!error) {
         this.logDebug(`Successfully polled for flag updates, next poll in ${this.configurations.pollingInterval}ms. `)
-        this.eventBus.emit(Event.POLLING_CHANGES, this.storage)
+        this.eventBus.emit(Event.POLLING_CHANGED, this.storage)
         return
       }
 

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -28,7 +28,6 @@ export default class Poller {
     // Don't start polling immediately as we have already fetched flags on client initialization
     // TODO UNCOMMENT THIS!!!!!!!!
     this.timeoutId = setTimeout(() => this.poll(), this.configurations.pollingInterval)
-    this.poll()
   }
 
   private poll(): void {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -132,6 +132,8 @@ export class Streamer {
     }
     // Stop the task that listens for heartbeats
     clearInterval(this.readTimeoutCheckerId)
+
+    this.eventBus.emit(Event.STOPPED)
     // if we are still in polling mode when close is called, then stop polling
     this.stopFallBackPolling()
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export enum Event {
   READY = 'ready',
   CONNECTED = 'connected',
   DISCONNECTED = 'disconnected',
+  STOPPED = 'stopped',
   POLLING = 'polling',
   POLLING_STOPPED = 'polling stopped',
   POLLING_CHANGED = 'polling changed',
@@ -53,8 +54,10 @@ export type FetchFlagsResult = { type: 'success'; data: Evaluation[] } | { type:
 export interface EventCallbackMapping {
   [Event.READY]: (flags: Record<string, VariationValue>) => void
   [Event.CONNECTED]: () => void
+  [Event.STOPPED]: () => void
   [Event.POLLING]: () => void
   [Event.POLLING_STOPPED]: () => void
+  [Event.POLLING_CHANGED]: () => void
   [Event.DISCONNECTED]: () => void
   [Event.FLAGS_LOADED]: (evaluations: Evaluation[]) => void
   [Event.CACHE_LOADED]: (evaluations: Evaluation[]) => void

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,7 @@ export enum Event {
   DISCONNECTED = 'disconnected',
   POLLING = 'polling',
   POLLING_STOPPED = 'polling stopped',
-  POLLING_CHANGES = 'polling changes',
+  POLLING_CHANGED = 'polling changed',
   FLAGS_LOADED = 'flags loaded',
   CACHE_LOADED = 'cache loaded',
   CHANGED = 'changed',

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,8 @@ export interface Evaluation {
   deleted?: boolean // mark that feature flag is deleted
 }
 
+export type FetchFlagsResult = { type: 'success'; data: Evaluation[] } | { type: 'error'; error: any }
+
 export interface EventCallbackMapping {
   [Event.READY]: (flags: Record<string, VariationValue>) => void
   [Event.CONNECTED]: () => void
@@ -95,7 +97,7 @@ export interface Options {
   baseUrl?: string
   eventUrl?: string
   eventsSyncInterval?: number
-  pollingInterval?: number,
+  pollingInterval?: number
   streamEnabled?: boolean
   pollingEnabled?: boolean
   allAttributesPrivate?: boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export enum Event {
   DISCONNECTED = 'disconnected',
   POLLING = 'polling',
   POLLING_STOPPED = 'polling stopped',
+  POLLING_CHANGES = 'polling changes',
   FLAGS_LOADED = 'flags loaded',
   CACHE_LOADED = 'cache loaded',
   CHANGED = 'changed',


### PR DESCRIPTION
# What
Emits a new POLLING_CHANGED event which includes the response from `fetchFlags` 
This is achieved by updating the `fetchFlags` signature, instead of having it return a void promise on success and error on failure

# Why
So consumers can access the polled flags

# Testing
Manual 
- Flags are fetched by `fetchFlags` and emitted in the new event correctly. 
- Updated poller unit tests
