### PR TITLE
FFM-8967 Only send a changed event when streaming

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -423,7 +423,12 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
       logDebug('Flag variation has changed for ', evaluation.identifier)
       storage[evaluation.flag] = value
       evaluations[evaluation.flag] = { ...evaluation, value }
-      sendEvent(evaluation)
+
+      // We want to notify for streaming events only.
+      // Polling emits its own events, so don't want to duplicate these.
+      if (configurations.streamEnabled && !poller.isPolling()) {
+        sendEvent(evaluation)
+      }
     }
     startMetricsCollector()
   }


### PR DESCRIPTION
# What
Only emits `CHANGED` if streaming is enabled and polling isn't running, as polling mode emits its own events

# Why
So the same evaluation event isn't duplicated when streaming and polling is enabled