### PR TITLE
FFM-8967 Remove `POLLING_CHANGED` event

### DIFF
--- a/src/__tests__/poller.test.ts
+++ b/src/__tests__/poller.test.ts
@@ -64,6 +64,8 @@ describe('Poller', () => {
 
     currentPoller.start()
     currentPoller.start()
+    expect(mockEventBus.emit).toHaveBeenNthCalledWith(1, Event.POLLING)
+
     expect(testArgs.logSpy).toHaveBeenCalledTimes(2)
 
     expect(mockEventBus.emit).toHaveBeenCalled()

--- a/src/index.ts
+++ b/src/index.ts
@@ -423,7 +423,12 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
       logDebug('Flag variation has changed for ', evaluation.identifier)
       storage[evaluation.flag] = value
       evaluations[evaluation.flag] = { ...evaluation, value }
-      sendEvent(evaluation)
+
+      // We want to notify for streaming events only.
+      // Polling emits its own events, so don't want to duplicate these.
+      if (configurations.streamEnabled && !poller.isPolling()) {
+        sendEvent(evaluation)
+      }
     }
     startMetricsCollector()
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -423,12 +423,7 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
       logDebug('Flag variation has changed for ', evaluation.identifier)
       storage[evaluation.flag] = value
       evaluations[evaluation.flag] = { ...evaluation, value }
-
-      // We want to notify for streaming events only.
-      // Polling emits its own events, so don't want to duplicate these.
-      if (configurations.streamEnabled && !poller.isPolling()) {
-        sendEvent(evaluation)
-      }
+      sendEvent(evaluation)
     }
     startMetricsCollector()
   }

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -41,7 +41,6 @@ export default class Poller {
 
       if (result.type === 'success') {
         this.logDebug(`Successfully polled for flag updates, next poll in ${this.configurations.pollingInterval}ms. `)
-        this.eventBus.emit(Event.POLLING_CHANGED, result.data)
         return
       }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,6 @@ export enum Event {
   STOPPED = 'stopped',
   POLLING = 'polling',
   POLLING_STOPPED = 'polling stopped',
-  POLLING_CHANGED = 'polling changed',
   FLAGS_LOADED = 'flags loaded',
   CACHE_LOADED = 'cache loaded',
   CHANGED = 'changed',
@@ -57,7 +56,6 @@ export interface EventCallbackMapping {
   [Event.STOPPED]: () => void
   [Event.POLLING]: () => void
   [Event.POLLING_STOPPED]: () => void
-  [Event.POLLING_CHANGED]: () => void
   [Event.DISCONNECTED]: () => void
   [Event.FLAGS_LOADED]: (evaluations: Evaluation[]) => void
   [Event.CACHE_LOADED]: (evaluations: Evaluation[]) => void


### PR DESCRIPTION
# What
Removes the `POLLING_CHANGED` event which was initially fired on each successful poll. 

# Why
The SDK's `CHANGED` event is generic for any flag changes, and introducing a specific polling change event was not compatible with the design of the SDK.