### PR TITLE
FFM-9776 Deprecate unsupported options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-javascript-client-sdk",
-  "version": "1.19.2",
+  "version": "1.20.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.19.2",
+      "version": "1.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-javascript-client-sdk",
-  "version": "1.19.2",
+  "version": "1.20.0",
   "author": "Harness",
   "license": "Apache-2.0",
   "main": "dist/sdk.cjs.js",

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,12 +102,12 @@ export interface Options {
   streamEnabled?: boolean
   pollingEnabled?: boolean
   /**
-   * @deprecated This property was never supported and was mistakenly included in the API.
+   * @deprecated This feature was only available during initial alpha builds and was mistakenly not removed from the API
    * It will be removed in the next version.
    */
   allAttributesPrivate?: boolean
   /**
-   * @deprecated This property was never supported and was mistakenly included in the API.
+   * @deprecated This feature was only available during initial alpha builds and was mistakenly not removed from the API
    * It will be removed in the next version.
    */
   privateAttributeNames?: string[]

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,7 +101,15 @@ export interface Options {
   pollingInterval?: number
   streamEnabled?: boolean
   pollingEnabled?: boolean
+  /**
+   * @deprecated This property was never supported and was mistakenly included in the API.
+   * It will be removed in the next version.
+   */
   allAttributesPrivate?: boolean
+  /**
+   * @deprecated This property was never supported and was mistakenly included in the API.
+   * It will be removed in the next version.
+   */
   privateAttributeNames?: string[]
   debug?: boolean
   cache?: boolean | CacheOptions

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,13 +102,13 @@ export interface Options {
   streamEnabled?: boolean
   pollingEnabled?: boolean
   /**
-   * @deprecated This feature was only available during initial alpha builds and was mistakenly not removed from the API
-   * It will be removed in the next version.
+   * @deprecated This feature was only available during initial alpha builds and was mistakenly not removed from the
+   * API. It will be removed in the next version.
    */
   allAttributesPrivate?: boolean
   /**
-   * @deprecated This feature was only available during initial alpha builds and was mistakenly not removed from the API
-   * It will be removed in the next version.
+   * @deprecated This feature was only available during initial alpha builds and was mistakenly not removed from the
+   * API. It will be removed in the next version.
    */
   privateAttributeNames?: string[]
   debug?: boolean

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,8 +10,6 @@ export const defaultOptions: Options = {
   eventsSyncInterval: MIN_EVENTS_SYNC_INTERVAL,
   pollingInterval: MIN_POLLING_INTERVAL,
   streamEnabled: true,
-  allAttributesPrivate: false,
-  privateAttributeNames: [],
   cache: false
 }
 


### PR DESCRIPTION
# What
Deprecates from `Options`: 

- `allAttributesPrivate`
- `privateAttributeNames` 

# Why
These Options properties were never supported or implemented correctly, and should not have been included in the API. 