### PR TITLE
feat: [FFM-10231]: Use SHA-256 hash of target id and sdk key as cache id

### DIFF
--- a/examples/preact/package-lock.json
+++ b/examples/preact/package-lock.json
@@ -18,7 +18,7 @@
     },
     "../..": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^3.1.2",

--- a/examples/react-redux/package-lock.json
+++ b/examples/react-redux/package-lock.json
@@ -27,7 +27,7 @@
     },
     "../..": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^3.1.2",

--- a/examples/react/package-lock.json
+++ b/examples/react/package-lock.json
@@ -15,7 +15,7 @@
     },
     "../..": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^3.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-javascript-client-sdk",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-javascript-client-sdk",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "author": "Harness",
   "license": "Apache-2.0",
   "main": "dist/sdk.cjs.js",

--- a/src/__tests__/cache.test.ts
+++ b/src/__tests__/cache.test.ts
@@ -7,9 +7,18 @@ import {
   updateCachedEvaluation
 } from '../cache'
 import type { Evaluation } from '../types'
+import { TextEncoder, TextDecoder } from 'util'
+import crypto from 'crypto'
+
+Object.defineProperty(global.self, 'crypto', {
+  value: {
+    subtle: crypto.webcrypto.subtle
+  }
+})
+Object.assign(global, { TextDecoder, TextEncoder })
 
 describe('Cache', () => {
-  const targetIdentifier = 'TEST_123'
+  const cacheId = 'some-cache-id'
 
   function primeCache(): Evaluation[] {
     const evals = [
@@ -22,7 +31,7 @@ describe('Cache', () => {
       }
     ]
 
-    window.localStorage.setItem(getCacheId(targetIdentifier), JSON.stringify(evals))
+    window.localStorage.setItem(cacheId, JSON.stringify(evals))
 
     return evals
   }
@@ -33,59 +42,59 @@ describe('Cache', () => {
 
   describe('getCacheId', () => {
     test('it should prefix the target ID', async () => {
-      expect(getCacheId(targetIdentifier)).toBe('HARNESS_FF_CACHE_' + targetIdentifier)
+      expect(await getCacheId('yatta')).toBe(
+        'HARNESS_FF_CACHE_248ad761f624bc5b0aed163c1d1585f562b4c058616a41f1919d00f669adbf1c'
+      )
     })
   })
 
   describe('loadFromCache', () => {
     test('it should return an empty array if nothing is stored', async () => {
-      expect(loadFromCache(targetIdentifier)).toEqual([])
+      expect(loadFromCache(cacheId)).toEqual([])
     })
 
     test('it should return the evaluations that were set', async () => {
       const evals = primeCache()
 
-      expect(loadFromCache(targetIdentifier)).toEqual(evals)
+      expect(loadFromCache(cacheId)).toEqual(evals)
     })
 
     test('it should return an empty array if the stored evaluations are malformed', async () => {
-      window.localStorage.setItem(getCacheId(targetIdentifier), 'abc123]{.')
+      window.localStorage.setItem(cacheId, 'abc123]{.')
 
-      expect(loadFromCache(targetIdentifier)).toEqual([])
+      expect(loadFromCache(cacheId)).toEqual([])
     })
 
     test('it should return an empty array if the stored evaluations timestamp exceeds the ttl', async () => {
       primeCache()
-      window.localStorage.setItem(getCacheId(targetIdentifier) + '.ts', '0')
+      window.localStorage.setItem(cacheId + '.ts', '0')
 
-      expect(loadFromCache(targetIdentifier, { ttl: 60000 })).toEqual([])
+      expect(loadFromCache(cacheId, { ttl: 60000 })).toEqual([])
     })
 
     test('it should return the evaluations if the stored evaluations timestamp does not exceed the ttl', async () => {
       const evals = primeCache()
-      window.localStorage.setItem(getCacheId(targetIdentifier) + '.ts', Date.now().toString())
+      window.localStorage.setItem(cacheId + '.ts', Date.now().toString())
 
-      expect(loadFromCache(targetIdentifier, { ttl: 60000 })).toEqual(evals)
+      expect(loadFromCache(cacheId, { ttl: 60000 })).toEqual(evals)
     })
   })
 
   describe('saveToCache', () => {
     test('it should persist the passed evaluations', async () => {
-      expect(window.localStorage.getItem(getCacheId(targetIdentifier))).toBeFalsy()
+      expect(window.localStorage.getItem(cacheId)).toBeFalsy()
 
       const evals: Evaluation[] = [{ flag: 'F1', deleted: false, value: 'true', identifier: 'true', kind: 'boolean' }]
-      saveToCache(targetIdentifier, evals)
+      saveToCache(cacheId, evals)
 
-      expect(window.localStorage.getItem(getCacheId(targetIdentifier))).toBeTruthy()
+      expect(window.localStorage.getItem(cacheId)).toBeTruthy()
     })
 
     test('it should save the timestamp of when the evaluations were stored', async () => {
       const now = Date.now()
-      saveToCache(targetIdentifier, [
-        { flag: 'F1', deleted: false, value: 'true', identifier: 'true', kind: 'boolean' }
-      ])
+      saveToCache(cacheId, [{ flag: 'F1', deleted: false, value: 'true', identifier: 'true', kind: 'boolean' }])
 
-      const timestamp = parseInt(window.localStorage.getItem(getCacheId(targetIdentifier) + '.ts'))
+      const timestamp = parseInt(window.localStorage.getItem(cacheId + '.ts'))
       expect(timestamp / 1000).toBeCloseTo(now / 1000, 0)
     })
   })
@@ -95,20 +104,18 @@ describe('Cache', () => {
       const evals = primeCache()
 
       const updatedEval = { ...evals[0], value: 'false', identifier: 'false' }
-      updateCachedEvaluation(targetIdentifier, updatedEval)
+      updateCachedEvaluation(cacheId, updatedEval)
 
-      expect(JSON.parse(window.localStorage.getItem(getCacheId(targetIdentifier)) as string)).toContainEqual(
-        updatedEval
-      )
+      expect(JSON.parse(window.localStorage.getItem(cacheId) as string)).toContainEqual(updatedEval)
     })
 
     test('it should append a new evaluation ', async () => {
       const evals = primeCache()
 
       const newEval = { flag: 'F2', deleted: false, value: 'false', identifier: 'false', kind: 'boolean' }
-      updateCachedEvaluation(targetIdentifier, newEval)
+      updateCachedEvaluation(cacheId, newEval)
 
-      const storedEvals = JSON.parse(window.localStorage.getItem(getCacheId(targetIdentifier)) as string)
+      const storedEvals = JSON.parse(window.localStorage.getItem(cacheId) as string)
       expect(storedEvals).toHaveLength(evals.length + 1)
       expect(storedEvals).toContainEqual(newEval)
     })
@@ -118,9 +125,9 @@ describe('Cache', () => {
     test('it should remove an existing cached item', async () => {
       const evals = primeCache()
 
-      removeCachedEvaluation(targetIdentifier, evals[0].flag)
+      removeCachedEvaluation(cacheId, evals[0].flag)
 
-      const storedEvals = JSON.parse(window.localStorage.getItem(getCacheId(targetIdentifier)) as string)
+      const storedEvals = JSON.parse(window.localStorage.getItem(cacheId) as string)
       expect(storedEvals).toHaveLength(evals.length - 1)
       expect(storedEvals).not.toContainEqual(evals[0])
     })
@@ -129,15 +136,15 @@ describe('Cache', () => {
   describe('clearCachedEvaluations', () => {
     test('it should clear stored evaluations and timestamp', async () => {
       primeCache()
-      window.localStorage.setItem(getCacheId(targetIdentifier) + '.ts', Date.now().toString())
+      window.localStorage.setItem(cacheId + '.ts', Date.now().toString())
 
-      expect(window.localStorage.getItem(getCacheId(targetIdentifier))).toBeTruthy()
-      expect(window.localStorage.getItem(getCacheId(targetIdentifier) + '.ts')).toBeTruthy()
+      expect(window.localStorage.getItem(cacheId)).toBeTruthy()
+      expect(window.localStorage.getItem(cacheId + '.ts')).toBeTruthy()
 
-      clearCachedEvaluations(targetIdentifier)
+      clearCachedEvaluations(cacheId)
 
-      expect(window.localStorage.getItem(getCacheId(targetIdentifier))).toBeFalsy()
-      expect(window.localStorage.getItem(getCacheId(targetIdentifier) + '.ts')).toBeFalsy()
+      expect(window.localStorage.getItem(cacheId)).toBeFalsy()
+      expect(window.localStorage.getItem(cacheId + '.ts')).toBeFalsy()
     })
   })
 })


### PR DESCRIPTION
This PR updates how the SDK builds the cache id to take into account the SDK Key to ensure that if multiple SDKs are in use in the same page using the same target id, they will have separate caches.