### PR TITLE
feat: [FFM-10455]: Add defensive code around btoa usage

### DIFF
--- a/examples/preact/package-lock.json
+++ b/examples/preact/package-lock.json
@@ -18,7 +18,7 @@
     },
     "../..": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^3.1.2",

--- a/examples/react-redux/package-lock.json
+++ b/examples/react-redux/package-lock.json
@@ -27,7 +27,7 @@
     },
     "../..": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^3.1.2",

--- a/examples/react/package-lock.json
+++ b/examples/react/package-lock.json
@@ -15,7 +15,7 @@
     },
     "../..": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^3.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-javascript-client-sdk",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-javascript-client-sdk",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "author": "Harness",
   "license": "Apache-2.0",
   "main": "dist/sdk.cjs.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import { Streamer } from './stream'
 import { getVariation } from './variation'
 import Poller from './poller'
 
-const SDK_VERSION = '1.22.0'
+const SDK_VERSION = '1.23.0'
 const SDK_INFO = `Javascript ${SDK_VERSION} Client`
 const METRICS_VALID_COUNT_INTERVAL = 500
 const fetch = globalThis.fetch
@@ -309,11 +309,13 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
         'Harness-SDK-Info': SDK_INFO
       }
 
-      const targetHeader = btoa(JSON.stringify(target))
+      if (globalThis.btoa) {
+        const targetHeader = globalThis.btoa(JSON.stringify(target))
 
-      // ensure encoded target is less than 1/4 of 1 MB
-      if (targetHeader.length < 262144) {
-        standardHeaders['Harness-Target'] = targetHeader
+        // ensure encoded target is less than 1/4 of 1 MB
+        if (targetHeader.length < 262144) {
+          standardHeaders['Harness-Target'] = targetHeader
+        }
       }
 
       logDebug('Authenticated', decoded)


### PR DESCRIPTION
This PR puts defensive code around the usage of `btoa`. In React Native this function reports as not being present, which prevents the React SDK being used in React Native.