### PR TITLE
[FFM-10442] - Disable streaming if Reactive Native + Android is detected

### DIFF
--- a/examples/preact/package-lock.json
+++ b/examples/preact/package-lock.json
@@ -18,7 +18,7 @@
     },
     "../..": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.23.0",
+      "version": "1.24.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^3.1.2",

--- a/examples/react-redux/package-lock.json
+++ b/examples/react-redux/package-lock.json
@@ -27,7 +27,7 @@
     },
     "../..": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.23.0",
+      "version": "1.24.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^3.1.2",

--- a/examples/react/package-lock.json
+++ b/examples/react/package-lock.json
@@ -15,7 +15,7 @@
     },
     "../..": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.23.0",
+      "version": "1.24.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^3.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-javascript-client-sdk",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.23.0",
+      "version": "1.24.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-javascript-client-sdk",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "author": "Harness",
   "license": "Apache-2.0",
   "main": "dist/sdk.cjs.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
     try {
       const { Platform } = require("react-native");
       if  (Platform.OS === 'android') {
-        console.warn("SDKCODE:1007 workaround applied - Android React Native detected - streaming will be disabled and polling enabled")
+        console.info("SDKCODE:1007 Android React Native detected - streaming will be disabled and polling enabled")
         configurations.pollingEnabled = true
         configurations.streamEnabled = false
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import { Streamer } from './stream'
 import { getVariation } from './variation'
 import Poller from './poller'
 
-const SDK_VERSION = '1.23.0'
+const SDK_VERSION = '1.24.0'
 const SDK_INFO = `Javascript ${SDK_VERSION} Client`
 const METRICS_VALID_COUNT_INTERVAL = 500
 const fetch = globalThis.fetch

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,19 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
     configurations.pollingInterval = MIN_POLLING_INTERVAL
   }
 
+  if (configurations.streamEnabled) {
+    try {
+      const { Platform } = require("react-native");
+      if  (Platform.OS === 'android') {
+        console.warn("SDKCODE:1007 workaround applied - Android React Native detected - streaming will be disabled and polling enabled")
+        configurations.pollingEnabled = true
+        configurations.streamEnabled = false
+      }
+    } catch (e) {
+      // ignore
+    }
+  }
+
   const logDebug = (message: string, ...args: any[]) => {
     if (configurations.debug) {
       // tslint:disable-next-line:no-console


### PR DESCRIPTION
**What**
Make the JS SDK fall back to polling when it detects that it is running inside Android on React native

**Why**
XMLHttpRequest does not work correctly on React Native when Android is used. For more context: https://github.com/facebook/react-native/issues/28835 We will use this work around until a better fix is identified.

**Testing**
Manual