### PR TITLE
feat: [FFM-10772]: Allow override of cache storage mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,8 @@ interface Options {
   pollingInterval?: number
   pollingEnabled?: boolean
   streamEnabled?: boolean
-  allAttributesPrivate?: boolean
-  privateAttributeNames?: string[]
-  debug?: boolean
+  debug?: boolean,
+  cache?: boolean | CacheOptions
 }
 ```
 
@@ -158,6 +157,10 @@ client.on(Event.POLLING_STOPPED, () => {
 
 client.on(Event.ERROR, error => {
   // Event happens when connection some error has occurred
+})
+
+client.on(Event.ERROR_CACHE, error => {
+  // Event happens when an error occurs when accessing the cache
 })
 
 client.on(Event.ERROR_AUTH, error => {
@@ -262,7 +265,11 @@ The `cache` option can also be passed as an object with the following options.
 
 ```typescript
 interface CacheOptions {
-  ttl?: number // maximum age of stored cache, in ms, before it is considered stale 
+  // maximum age of stored cache, in ms, before it is considered stale
+  ttl?: number
+  // storage mechanism to use, conforming to the Web Storage API standard, can be either synchronous or asynchronous
+  // defaults to localStorage
+  storage?: AsyncStorage | SyncStorage
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-javascript-client-sdk",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.24.0",
+      "version": "1.25.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-javascript-client-sdk",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "author": "Harness",
   "license": "Apache-2.0",
   "main": "dist/sdk.cjs.js",

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,0 +1,58 @@
+import { getConfiguration, MIN_EVENTS_SYNC_INTERVAL, MIN_POLLING_INTERVAL } from '../utils'
+
+describe('utils', () => {
+  describe('getConfiguration', () => {
+    test('it should set defaults', async () => {
+      expect(getConfiguration({})).toEqual({
+        debug: false,
+        baseUrl: 'https://config.ff.harness.io/api/1.0',
+        eventUrl: 'https://events.ff.harness.io/api/1.0',
+        eventsSyncInterval: MIN_EVENTS_SYNC_INTERVAL,
+        pollingInterval: MIN_POLLING_INTERVAL,
+        streamEnabled: true,
+        pollingEnabled: true,
+        cache: false
+      })
+    })
+
+    test('it should enable polling when streaming is enabled', async () => {
+      const result = getConfiguration({ streamEnabled: true })
+
+      expect(result).toHaveProperty('pollingEnabled', true)
+      expect(result).toHaveProperty('streamEnabled', true)
+    })
+
+    test('it should disable polling when streaming is disabled', async () => {
+      const result = getConfiguration({ streamEnabled: false })
+
+      expect(result).toHaveProperty('pollingEnabled', false)
+      expect(result).toHaveProperty('streamEnabled', false)
+    })
+
+    test('it should enable polling when streaming is disabled and polling is enabled', async () => {
+      const result = getConfiguration({ pollingEnabled: true, streamEnabled: false })
+
+      expect(result).toHaveProperty('pollingEnabled', true)
+      expect(result).toHaveProperty('streamEnabled', false)
+    })
+
+    test('it should not allow eventsSyncInterval to be set below 60s', async () => {
+      expect(getConfiguration({ eventsSyncInterval: 1000 })).toHaveProperty(
+        'eventsSyncInterval',
+        MIN_EVENTS_SYNC_INTERVAL
+      )
+    })
+
+    test('it should allow eventsSyncInterval to be set above 60s', async () => {
+      expect(getConfiguration({ eventsSyncInterval: 100000 })).toHaveProperty('eventsSyncInterval', 100000)
+    })
+
+    test('it should not allow pollingInterval to be set below 60s', async () => {
+      expect(getConfiguration({ pollingInterval: 1000 })).toHaveProperty('pollingInterval', MIN_POLLING_INTERVAL)
+    })
+
+    test('it should allow pollingInterval to be set above 60s', async () => {
+      expect(getConfiguration({ pollingInterval: 100000 })).toHaveProperty('pollingInterval', 100000)
+    })
+  })
+})

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,24 +1,37 @@
-import type { CacheOptions, Evaluation } from './types'
+import type { AsyncStorage, CacheOptions, Evaluation, SyncStorage } from './types'
 
-export async function getCacheId(seed: string): Promise<string> {
-  const encoder = new TextEncoder()
-  const data = encoder.encode(seed)
-  const hashBuffer = await crypto.subtle.digest('SHA-256', data)
-  const hashArray = Array.from(new Uint8Array(hashBuffer))
-  const cacheId = hashArray.map(b => b.toString(16).padStart(2, '0')).join('')
-
-  return 'HARNESS_FF_CACHE_' + cacheId
+export interface GetCacheResponse {
+  loadFromCache: () => Promise<Evaluation[]>
+  saveToCache: (evaluations: Evaluation[]) => Promise<void>
+  updateCachedEvaluation: (evaluation: Evaluation) => Promise<void>
+  removeCachedEvaluation: (flagIdentifier: string) => Promise<void>
 }
 
-export function loadFromCache(cacheId: string, cacheOptions: CacheOptions = {}): Evaluation[] {
-  const timestamp = parseInt(window.localStorage.getItem(cacheId + '.ts'))
+export async function getCache(seed: string, cacheOptions: CacheOptions = {}): Promise<GetCacheResponse> {
+  const cacheId = await getCacheId(seed)
+  const storage = getStorage(cacheOptions)
+
+  return {
+    loadFromCache: () => loadFromCache(cacheId, storage, cacheOptions),
+    saveToCache: (evaluations: Evaluation[]) => saveToCache(cacheId, storage, evaluations),
+    updateCachedEvaluation: (evaluation: Evaluation) => updateCachedEvaluation(cacheId, storage, evaluation),
+    removeCachedEvaluation: (flagIdentifier: string) => removeCachedEvaluation(cacheId, storage, flagIdentifier)
+  }
+}
+
+async function loadFromCache(
+  cacheId: string,
+  storage: AsyncStorage,
+  cacheOptions: CacheOptions = {}
+): Promise<Evaluation[]> {
+  const timestamp = parseInt(await storage.getItem(cacheId + '.ts'))
 
   if (cacheOptions?.ttl && !isNaN(timestamp) && timestamp + cacheOptions.ttl < Date.now()) {
-    clearCachedEvaluations(cacheId)
+    await clearCachedEvaluations(cacheId, storage)
     return []
   }
 
-  const cachedEvaluations = window.localStorage.getItem(cacheId)
+  const cachedEvaluations = await storage.getItem(cacheId)
 
   if (cachedEvaluations) {
     try {
@@ -29,13 +42,18 @@ export function loadFromCache(cacheId: string, cacheOptions: CacheOptions = {}):
   return []
 }
 
-export function saveToCache(cacheId: string, evaluations: Evaluation[]): void {
-  window.localStorage.setItem(cacheId, JSON.stringify(evaluations))
-  window.localStorage.setItem(cacheId + '.ts', Date.now().toString())
+async function clearCachedEvaluations(cacheId: string, storage: AsyncStorage): Promise<void> {
+  await storage.removeItem(cacheId)
+  await storage.removeItem(cacheId + '.ts')
 }
 
-export function updateCachedEvaluation(cacheId: string, evaluation: Evaluation): void {
-  const cachedEvals = loadFromCache(cacheId)
+async function saveToCache(cacheId: string, storage: AsyncStorage, evaluations: Evaluation[]): Promise<void> {
+  await storage.setItem(cacheId, JSON.stringify(evaluations))
+  await storage.setItem(cacheId + '.ts', Date.now().toString())
+}
+
+async function updateCachedEvaluation(cacheId: string, storage: AsyncStorage, evaluation: Evaluation): Promise<void> {
+  const cachedEvals = await loadFromCache(cacheId, storage)
   const existingEval = cachedEvals.find(({ flag }) => flag === evaluation.flag)
 
   if (existingEval) {
@@ -44,21 +62,75 @@ export function updateCachedEvaluation(cacheId: string, evaluation: Evaluation):
     cachedEvals.push(evaluation)
   }
 
-  saveToCache(cacheId, cachedEvals)
+  await saveToCache(cacheId, storage, cachedEvals)
 }
 
-export function removeCachedEvaluation(cacheId: string, flagIdentifier: string): void {
-  const cachedEvals = loadFromCache(cacheId)
+async function removeCachedEvaluation(cacheId: string, storage: AsyncStorage, flagIdentifier: string): Promise<void> {
+  const cachedEvals = await loadFromCache(cacheId, storage)
   const existingEvalIndex = cachedEvals.findIndex(({ flag }) => flag === flagIdentifier)
 
   if (existingEvalIndex > -1) {
     cachedEvals.splice(existingEvalIndex, 1)
 
-    saveToCache(cacheId, cachedEvals)
+    await saveToCache(cacheId, storage, cachedEvals)
   }
 }
 
-export function clearCachedEvaluations(cacheId: string): void {
-  window.localStorage.removeItem(cacheId)
-  window.localStorage.removeItem(cacheId + '.ts')
+async function getCacheId(seed: string): Promise<string> {
+  let cacheId = seed
+
+  if (globalThis?.TextEncoder && globalThis?.crypto?.subtle?.digest) {
+    const encoder = new TextEncoder()
+    const data = encoder.encode(seed)
+    const hashBuffer = await crypto.subtle.digest('SHA-256', data)
+    const hashArray = Array.from(new Uint8Array(hashBuffer))
+    cacheId = hashArray.map(b => b.toString(16).padStart(2, '0')).join('')
+  } else if (globalThis.btoa) {
+    cacheId = btoa(seed)
+  }
+
+  return 'HARNESS_FF_CACHE_' + cacheId
+}
+
+function getStorage(cacheOptions: CacheOptions): AsyncStorage {
+  let storageOption: AsyncStorage | SyncStorage
+
+  if (
+    !cacheOptions.storage ||
+    typeof cacheOptions.storage !== 'object' ||
+    !('getItem' in cacheOptions.storage) ||
+    !('setItem' in cacheOptions.storage) ||
+    !('removeItem' in cacheOptions.storage)
+  ) {
+    if (globalThis.localStorage) {
+      storageOption = globalThis.localStorage
+    } else if (globalThis.sessionStorage) {
+      storageOption = globalThis.sessionStorage
+    } else {
+      storageOption = NullStorage
+    }
+  } else {
+    storageOption = cacheOptions.storage
+  }
+
+  return {
+    async getItem(key: string) {
+      const result = storageOption.getItem(key)
+      return result instanceof Promise ? await result : result
+    },
+    async setItem(key: string, value: string) {
+      const result = storageOption.setItem(key, value)
+      if (result instanceof Promise) await result
+    },
+    async removeItem(key: string) {
+      const result = storageOption.removeItem(key)
+      if (result instanceof Promise) await result
+    }
+  }
+}
+
+const NullStorage: SyncStorage = {
+  getItem: () => null,
+  setItem: () => void 0,
+  removeItem: () => void 0
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export enum Event {
   CACHE_LOADED = 'cache loaded',
   CHANGED = 'changed',
   ERROR = 'error',
+  ERROR_CACHE = 'cache error',
   ERROR_METRICS = 'metrics error',
   ERROR_AUTH = 'auth error',
   ERROR_FETCH_FLAGS = 'fetch flags error',
@@ -95,23 +96,48 @@ type FetchArgs = Parameters<typeof fetch>
 export type APIRequestMiddleware = (req: FetchArgs) => FetchArgs
 
 export interface Options {
+  /**
+   * Override the default base URL for the SDK to communicate with the Harness Feature Flags service.
+   * @default https://config.ff.harness.io/api/1.0
+   */
   baseUrl?: string
+  /**
+   * Override the default metrics URL for the SDK to communicate with the Harness Feature Flags
+   * metrics service.
+   * @default https://events.ff.harness.io/api/1.0
+   */
   eventUrl?: string
+  /**
+   * The interval in milliseconds to sync metrics with the Harness Feature Flags metrics service.
+   * @default 60000
+   */
   eventsSyncInterval?: number
+  /**
+   * The interval in milliseconds to poll the Harness Feature Flags service for updates when polling is enabled
+   * and streaming is disabled.
+   * @default 60000
+   */
   pollingInterval?: number
+  /**
+   * Whether to enable the streaming feature. If set to `false` and polling enabled, the SDK will use polling to
+   * check for updates.
+   * @default true
+   */
   streamEnabled?: boolean
+  /**
+   * Whether to enable polling. If set to `false`, the SDK will not poll for updates.
+   * @default false
+   */
   pollingEnabled?: boolean
   /**
-   * @deprecated This feature was only available during initial alpha builds and was mistakenly not removed from the
-   * API. It will be removed in the next version.
+   * Whether to enable debug logging.
+   * @default false
    */
-  allAttributesPrivate?: boolean
-  /**
-   * @deprecated This feature was only available during initial alpha builds and was mistakenly not removed from the
-   * API. It will be removed in the next version.
-   */
-  privateAttributeNames?: string[]
   debug?: boolean
+  /**
+   * Whether to enable caching.
+   * @default false
+   */
   cache?: boolean | CacheOptions
 }
 
@@ -123,6 +149,27 @@ export interface MetricsInfo {
   lastAccessed: number
 }
 
+export interface SyncStorage {
+  getItem: (key: string) => string | null
+  setItem: (key: string, value: string) => void
+  removeItem: (key: string) => void
+}
+
+export interface AsyncStorage {
+  getItem: (key: string) => Promise<string | null>
+  setItem: (key: string, value: string) => Promise<void>
+  removeItem: (key: string) => Promise<void>
+}
+
 export interface CacheOptions {
+  /**
+   * Time to live in milliseconds
+   * @default Infinity
+   */
   ttl?: number
+  /**
+   * Storage to use for caching
+   * @default localStorage
+   */
+  storage?: AsyncStorage | SyncStorage
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,6 +20,27 @@ export const getConfiguration = (options: Options): Options => {
     config.pollingEnabled = config.streamEnabled
   }
 
+  if (config.eventsSyncInterval < MIN_EVENTS_SYNC_INTERVAL) {
+    config.eventsSyncInterval = MIN_EVENTS_SYNC_INTERVAL
+  }
+
+  if (config.pollingInterval < MIN_POLLING_INTERVAL) {
+    config.pollingInterval = MIN_POLLING_INTERVAL
+  }
+
+  if (config.streamEnabled) {
+    try {
+      const { Platform } = require('react-native')
+      if (Platform.OS === 'android') {
+        console.info('SDKCODE:1007 Android React Native detected - streaming will be disabled and polling enabled')
+        config.pollingEnabled = true
+        config.streamEnabled = false
+      }
+    } catch (e) {
+      // ignore
+    }
+  }
+
   return config
 }
 


### PR DESCRIPTION
This PR updates the cache support to allow overriding of the cache storage mechanism from the default of `localStorage` to instead being any class that's compatible with the Web Storage API standard. The cache mechanism can also be asynchronous. This PR also adds information about each of the configuration options, removes 2 previously deprecated config options and removes code which stores metrics to `localStorage` on shutdown.