### PR TITLE
fix: [FFM-10810]: Remove React Native Android detection

### DIFF
--- a/examples/preact/package-lock.json
+++ b/examples/preact/package-lock.json
@@ -18,7 +18,7 @@
     },
     "../..": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.24.0",
+      "version": "1.25.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^3.1.2",
@@ -1268,9 +1268,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "2.9.16",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.16.tgz",
-      "integrity": "sha512-X+6q8KPyeuBvTQV8AVSnKDvXoBMnTx8zxh54sOwmmuOdxkjMmEJXH2UEchA+vTMps1xw9vL64uwJOWryULg7nA==",
+      "version": "2.9.17",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.17.tgz",
+      "integrity": "sha512-XxcRzra6d7xrKXH66jZUgb+srThoPu+TLJc06GifUyKq9JmjHkc1Numc8ra0h56rju2jfVWw3B3fs5l3OFMvUw==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.14.27",
@@ -2139,9 +2139,9 @@
       "dev": true
     },
     "vite": {
-      "version": "2.9.16",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.16.tgz",
-      "integrity": "sha512-X+6q8KPyeuBvTQV8AVSnKDvXoBMnTx8zxh54sOwmmuOdxkjMmEJXH2UEchA+vTMps1xw9vL64uwJOWryULg7nA==",
+      "version": "2.9.17",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.17.tgz",
+      "integrity": "sha512-XxcRzra6d7xrKXH66jZUgb+srThoPu+TLJc06GifUyKq9JmjHkc1Numc8ra0h56rju2jfVWw3B3fs5l3OFMvUw==",
       "dev": true,
       "requires": {
         "esbuild": "^0.14.27",

--- a/examples/react-redux/package-lock.json
+++ b/examples/react-redux/package-lock.json
@@ -27,7 +27,7 @@
     },
     "../..": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.24.0",
+      "version": "1.25.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^3.1.2",
@@ -7755,9 +7755,9 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "funding": [
         {
           "type": "individual",
@@ -21381,9 +21381,9 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
     },
     "follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw=="
     },
     "for-each": {
       "version": "0.3.3",

--- a/examples/react/package-lock.json
+++ b/examples/react/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "react",
       "dependencies": {
         "@harnessio/ff-javascript-client-sdk": "../../",
         "react": "^17.0.1",
@@ -15,7 +16,7 @@
     },
     "../..": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.24.0",
+      "version": "1.25.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^3.1.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,8 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
 
   const initCache = async () => {
     if (configurations.cache) {
+      logDebug('initializing cache')
+
       try {
         let initialLoad = true
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,19 +28,6 @@ export const getConfiguration = (options: Options): Options => {
     config.pollingInterval = MIN_POLLING_INTERVAL
   }
 
-  if (config.streamEnabled) {
-    try {
-      const { Platform } = require('react-native')
-      if (Platform.OS === 'android') {
-        console.info('SDKCODE:1007 Android React Native detected - streaming will be disabled and polling enabled')
-        config.pollingEnabled = true
-        config.streamEnabled = false
-      }
-    } catch (e) {
-      // ignore
-    }
-  }
-
   return config
 }
 


### PR DESCRIPTION
Unfortunately the solution to detect React Native running on Android caused issues with typescript projects and a warning being displayed; this PR removes that detection. This PR also adds an extra debug message and updates the examples' dependencies.