### PR TITLE
fix: [FFM-11103]: Replace btoa usage with custom base64 encoding to handle non-ascii characters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-javascript-client-sdk",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.26.0",
+      "version": "1.26.1",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-javascript-client-sdk",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "author": "Harness",
   "license": "Apache-2.0",
   "main": "dist/sdk.cjs.js",

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { getConfiguration, MIN_EVENTS_SYNC_INTERVAL, MIN_POLLING_INTERVAL } from '../utils'
+import { encodeTarget, getConfiguration, MIN_EVENTS_SYNC_INTERVAL, MIN_POLLING_INTERVAL } from '../utils'
 import type { Logger } from '../types'
 
 describe('utils', () => {
@@ -75,6 +75,28 @@ describe('utils', () => {
 
       result.logger.debug('hello')
       expect(logger.debug).toHaveBeenCalledWith('hello')
+    })
+  })
+
+  describe('encodeTarget', () => {
+    test('it should properly encode with plain latin characters', async () => {
+      expect(
+        encodeTarget({ identifier: 'test-identifier', name: 'Test Name', attributes: { hello: 'world' } })
+      ).toEqual(
+        'eyJpZGVudGlmaWVyIjoidGVzdC1pZGVudGlmaWVyIiwibmFtZSI6IlRlc3QgTmFtZSIsImF0dHJpYnV0ZXMiOnsiaGVsbG8iOiJ3b3JsZCJ9fQ=='
+      )
+    })
+
+    test('it should properly encode with unicode characters', async () => {
+      expect(
+        encodeTarget({
+          identifier: 'test-identifier',
+          name: 'Test Name',
+          attributes: { somethingInJapanese: '日本語で何か' }
+        })
+      ).toEqual(
+        'eyJpZGVudGlmaWVyIjoidGVzdC1pZGVudGlmaWVyIiwibmFtZSI6IlRlc3QgTmFtZSIsImF0dHJpYnV0ZXMiOnsic29tZXRoaW5nSW5KYXBhbmVzZSI6IuaXpeacrOiqnuOBp+S9leOBiyJ9fQ=='
+      )
     })
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,14 +15,14 @@ import type {
   VariationValue
 } from './types'
 import { Event } from './types'
-import { defer, getConfiguration } from './utils'
+import { defer, encodeTarget, getConfiguration } from './utils'
 import { addMiddlewareToFetch } from './request'
 import { Streamer } from './stream'
 import { getVariation } from './variation'
 import Poller from './poller'
 import { getCache } from './cache'
 
-const SDK_VERSION = '1.25.0'
+const SDK_VERSION = '1.26.1'
 const SDK_INFO = `Javascript ${SDK_VERSION} Client`
 const METRICS_VALID_COUNT_INTERVAL = 500
 const fetch = globalThis.fetch
@@ -342,13 +342,11 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
           'Harness-SDK-Info': SDK_INFO
         }
 
-        if (globalThis.btoa) {
-          const targetHeader = globalThis.btoa(JSON.stringify(target))
+        const targetHeader = encodeTarget(target)
 
-          // ensure encoded target is less than 1/4 of 1 MB
-          if (targetHeader.length < 262144) {
-            standardHeaders['Harness-Target'] = targetHeader
-          }
+        // ensure encoded target is less than 1/4 of 1 MB
+        if (targetHeader.length < 262144) {
+          standardHeaders['Harness-Target'] = targetHeader
         }
 
         logDebug('Authenticated', decoded)


### PR DESCRIPTION
This PR replaces the usage of `btoa` with a custom base64 encoding. `btoa` does not handle non-ascii characters.