### PR TITLE
FFM-10924 Streaming disconnect log level changes

### DIFF
--- a/examples/preact/package-lock.json
+++ b/examples/preact/package-lock.json
@@ -18,7 +18,7 @@
     },
     "../..": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.26.0",
+      "version": "1.26.2",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^3.1.2",

--- a/examples/react-redux/package-lock.json
+++ b/examples/react-redux/package-lock.json
@@ -27,7 +27,7 @@
     },
     "../..": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.26.0",
+      "version": "1.26.2",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^3.1.2",

--- a/examples/react/package-lock.json
+++ b/examples/react/package-lock.json
@@ -15,7 +15,7 @@
     },
     "../..": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.26.0",
+      "version": "1.26.2",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^3.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-javascript-client-sdk",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.26.1",
+      "version": "1.26.2",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-javascript-client-sdk",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "author": "Harness",
   "license": "Apache-2.0",
   "main": "dist/sdk.cjs.js",

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -11,6 +11,7 @@ export class Streamer {
   private readTimeoutCheckerId: any
   private connectionOpened = false
   private disconnectEventEmitted = false
+  private reconnectAttempts = 0;  // Reconnect attempt counter
 
   constructor(
     private eventBus: Emitter,
@@ -40,22 +41,27 @@ export class Streamer {
     const onConnected = () => {
       this.logDebugMessage('Stream connected')
       this.eventBus.emit(Event.CONNECTED)
+      this.reconnectAttempts = 0;
     }
 
     const onDisconnect = () => {
       clearInterval(this.readTimeoutCheckerId)
       const reconnectDelayMs = getRandom(1000, 10000)
+      this.reconnectAttempts++;
       this.logDebugMessage('Stream disconnected, will reconnect in ' + reconnectDelayMs + 'ms')
       if (!this.disconnectEventEmitted) {
         this.eventBus.emit(Event.DISCONNECTED)
         this.disconnectEventEmitted = true
+      }
+      if (this.reconnectAttempts >= 5 && this.reconnectAttempts % 5 === 0) {
+        this.logErrorMessage(`Failed to reconnect after ${this.reconnectAttempts} attempts`);
       }
       setTimeout(() => this.start(), reconnectDelayMs)
     }
 
     const onFailed = (msg: string) => {
       if (!!msg) {
-        this.logErrorMessage('Stream has issue', msg)
+        this.logDebugMessage('Stream has issue', msg)
       }
 
       // Fallback to polling while we have a stream failure
@@ -97,19 +103,11 @@ export class Streamer {
       onFailed('SSE timeout')
     }
 
-    // XMLHttpRequest doesn't fire an `onload` event when used to open an SSE connection, but leaving this listener
-    // here, in case there are some edge cases where it's fired and so need to handle the reconnect.
+    // XMLHttpRequest fires `onload` when a request completes successfully, meaning the entire content has been download.
+    // For SSE, if it fires it indicates an invalid state and we should reconnect
     this.xhr.onload = () => {
-      if (this.xhr.status >= 400 && this.xhr.status <= 599) {
-        onFailed(`HTTP code ${this.xhr.status}`)
-        return
-      }
-
-      if (!this.connectionOpened) {
-        onConnected()
-        this.connectionOpened = true
-        this.disconnectEventEmitted = false
-      }
+      onFailed(`Received XMLHttpRequest onLoad event: ${this.xhr.status}`)
+      return
     }
 
     let offset = 0
@@ -135,7 +133,7 @@ export class Streamer {
     this.readTimeoutCheckerId = setInterval(() => {
       // this task will kill and restart the SSE connection if no data or heartbeat has arrived in a while
       if (lastActivity < Date.now() - SSE_TIMEOUT_MS) {
-        this.logErrorMessage('SSE read timeout')
+        this.logDebugMessage('SSE read timeout')
         this.xhr.abort()
       }
     }, SSE_TIMEOUT_MS)

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -11,7 +11,7 @@ export class Streamer {
   private readTimeoutCheckerId: any
   private connectionOpened = false
   private disconnectEventEmitted = false
-  private reconnectAttempts = 0;  // Reconnect attempt counter
+  private reconnectAttempts = 0 
 
   constructor(
     private eventBus: Emitter,
@@ -41,20 +41,22 @@ export class Streamer {
     const onConnected = () => {
       this.logDebugMessage('Stream connected')
       this.eventBus.emit(Event.CONNECTED)
-      this.reconnectAttempts = 0;
+      this.reconnectAttempts = 0
     }
 
     const onDisconnect = () => {
       clearInterval(this.readTimeoutCheckerId)
       const reconnectDelayMs = getRandom(1000, 10000)
-      this.reconnectAttempts++;
+      this.reconnectAttempts++
       this.logDebugMessage('Stream disconnected, will reconnect in ' + reconnectDelayMs + 'ms')
       if (!this.disconnectEventEmitted) {
         this.eventBus.emit(Event.DISCONNECTED)
         this.disconnectEventEmitted = true
       }
       if (this.reconnectAttempts >= 5 && this.reconnectAttempts % 5 === 0) {
-        this.logErrorMessage(`Failed to reconnect after ${this.reconnectAttempts} attempts`);
+        this.logErrorMessage(
+          `Reconnection failed after ${this.reconnectAttempts} attempts; attempting further reconnections.`
+        )
       }
       setTimeout(() => this.start(), reconnectDelayMs)
     }
@@ -103,7 +105,7 @@ export class Streamer {
       onFailed('SSE timeout')
     }
 
-    // XMLHttpRequest fires `onload` when a request completes successfully, meaning the entire content has been download.
+    // XMLHttpRequest fires `onload` when a request completes successfully, meaning the entire content has been downloaded.
     // For SSE, if it fires it indicates an invalid state and we should reconnect
     this.xhr.onload = () => {
       onFailed(`Received XMLHttpRequest onLoad event: ${this.xhr.status}`)

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -53,11 +53,13 @@ export class Streamer {
         this.eventBus.emit(Event.DISCONNECTED)
         this.disconnectEventEmitted = true
       }
+
       if (this.reconnectAttempts >= 5 && this.reconnectAttempts % 5 === 0) {
         this.logErrorMessage(
           `Reconnection failed after ${this.reconnectAttempts} attempts; attempting further reconnections.`
         )
       }
+
       setTimeout(() => this.start(), reconnectDelayMs)
     }
 


### PR DESCRIPTION
# What
- Now logs stream disconnect & timeouts as `debug` instead of `error`
- An `error` will be logged if reconnection is still being attempted after every `5, 10, 15...` attempts

# Why
We expect occasional stream disconnects/timeouts and the SDK will "self-heal" by reconnecting. Logging these as errors in the first instance is misleading and can cause users to be concerned unjustifiably.

# Testing
Manual - using proxy tool to simulate disconnects.