### PR TITLE
FFM-11788 Add `maxStreamRetries` config option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,32 @@ const client = initialize(
 )
 ```
 
+Max Stream Retries
+You can configure the maximum number of streaming retries before the SDK stops attempting to reconnect or falls back to polling (if enabled). The maxRetries option can be set to any positive number or Infinity for unlimited retries (which is the default).
+
+```typescript
+const options = {
+  maxRetries: 5, // Set the maximum number of retries for streaming. Default is Infinity.
+  streamEnabled: true, 
+  pollingEnabled: true, 
+  pollingInterval: 60000, 
+}
+
+const client = initialize(
+    'YOUR_SDK_KEY',
+    {
+      identifier: 'Harness1',
+      attributes: {
+        lastUpdated: Date(),
+        host: location.href
+      }
+    },
+    options
+)
+
+```
+If maxRetries is reached and pollingEnabled is true, the SDK will stay in polling mode. If pollingEnabled is false, the SDK will not poll, and evaluations will not be updated until the SDK Client is initialized again, for example if the app or page is restarted.
+
 ## Listening to events from the `client` instance.
 
 ```typescript

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-javascript-client-sdk",
-  "version": "1.26.3",
+  "version": "1.27.0-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.26.3",
+      "version": "1.27.0-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-javascript-client-sdk",
-  "version": "1.26.3",
+  "version": "1.27.0-rc.0",
   "author": "Harness",
   "license": "Apache-2.0",
   "main": "dist/sdk.cjs.js",

--- a/src/__tests__/stream.test.ts
+++ b/src/__tests__/stream.test.ts
@@ -1,0 +1,194 @@
+import { Streamer } from '../stream'
+import type { Options } from '../types'
+import { Event } from '../types'
+import { getRandom } from '../utils'
+import type { Emitter } from 'mitt'
+import type Poller from "../poller";
+
+jest.useFakeTimers()
+
+jest.mock('../utils.ts', () => ({
+  getRandom: jest.fn()
+}))
+
+const mockEventBus: Emitter = {
+  emit: jest.fn(),
+  on: jest.fn(),
+  off: jest.fn(),
+  all: new Map()
+}
+
+const mockXHR = {
+  open: jest.fn(),
+  setRequestHeader: jest.fn(),
+  send: jest.fn(),
+  abort: jest.fn(),
+  status: 0,
+  responseText: '',
+  onload: null,
+  onerror: null,
+  onprogress: null,
+  onabort: null,
+  ontimeout: null
+}
+
+global.XMLHttpRequest = jest.fn(() => mockXHR) as unknown as jest.MockedClass<typeof XMLHttpRequest>
+
+const logError = jest.fn()
+const logDebug = jest.fn()
+
+const getStreamer = (overrides: Partial<Options> = {}): Streamer => {
+  const options: Options = {
+    baseUrl: 'http://test',
+    eventUrl: 'http://event',
+    pollingInterval: 60000,
+    debug: true,
+    pollingEnabled: true,
+    streamEnabled: true,
+    ...overrides
+  }
+
+  return new Streamer(
+      mockEventBus,
+      options,
+      `${options.baseUrl}/stream`,
+      'test-api-key',
+      { 'Test-Header': 'value' },
+      { start: jest.fn(), stop: jest.fn(), isPolling: jest.fn() } as unknown as Poller,
+      logDebug,
+      logError,
+      jest.fn(),
+      3
+  )
+}
+
+describe('Streamer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should connect and emit CONNECTED event', () => {
+    const streamer = getStreamer()
+
+    streamer.start()
+    expect(mockXHR.open).toHaveBeenCalledWith('GET', 'http://test/stream')
+    expect(mockXHR.send).toHaveBeenCalled()
+
+    mockXHR.onprogress({} as ProgressEvent)
+    expect(mockEventBus.emit).toHaveBeenCalledWith(Event.CONNECTED)
+  })
+
+  it('should retry connecting on error and eventually fallback to polling', () => {
+    const streamer = getStreamer()
+
+    streamer.start()
+    expect(mockXHR.send).toHaveBeenCalled()
+
+    for (let i = 0; i < 3; i++) {
+      mockXHR.onerror({} as ProgressEvent)
+      jest.advanceTimersByTime(getRandom(1000, 10000))
+    }
+
+    expect(mockEventBus.emit).toHaveBeenCalledWith(Event.DISCONNECTED)
+    expect(logError).toHaveBeenCalledWith('Streaming:  Max streaming retries reached. Staying in polling mode.')
+  })
+
+  it('should not retry after max retries are exhausted', () => {
+    const streamer = getStreamer()
+
+    streamer.start()
+    expect(mockXHR.send).toHaveBeenCalled()
+
+    for (let i = 0; i < 3; i++) {
+      mockXHR.onerror({} as ProgressEvent)
+      jest.advanceTimersByTime(getRandom(1000, 10000))
+    }
+
+    mockXHR.onerror({} as ProgressEvent)
+    expect(logError).toHaveBeenCalledWith('Streaming:  Max streaming retries reached. Staying in polling mode.')
+    expect(mockEventBus.emit).toHaveBeenCalledWith(Event.DISCONNECTED)
+    expect(mockXHR.send).toHaveBeenCalledTimes(3) // Should not send after max retries
+  })
+
+  it('should fallback to polling on stream failure', () => {
+    const poller = { start: jest.fn(), stop: jest.fn(), isPolling: jest.fn() } as unknown as Poller
+    const streamer = new Streamer(
+        mockEventBus,
+        { baseUrl: 'http://test', eventUrl: 'http://event', pollingEnabled: true, streamEnabled: true, debug: true },
+        'http://test/stream',
+        'test-api-key',
+        { 'Test-Header': 'value' },
+        poller,
+        logDebug,
+        logError,
+        jest.fn(),
+        3
+    )
+
+    streamer.start()
+    expect(mockXHR.send).toHaveBeenCalled()
+
+    mockXHR.onerror({} as ProgressEvent)
+    jest.advanceTimersByTime(getRandom(1000, 10000))
+
+    expect(poller.start).toHaveBeenCalled()
+    expect(logDebug).toHaveBeenCalledWith('Streaming:  Falling back to polling mode while stream recovers')
+  })
+
+  it('should stop polling when close is called if in fallback polling mode', () => {
+    const poller = { start: jest.fn(), stop: jest.fn(), isPolling: jest.fn().mockReturnValue(true) } as unknown as Poller
+    const streamer = new Streamer(
+        mockEventBus,
+        { baseUrl: 'http://test', eventUrl: 'http://event', pollingEnabled: true, streamEnabled: true, debug: true },
+        'http://test/stream',
+        'test-api-key',
+        { 'Test-Header': 'value' },
+        poller,
+        logDebug,
+        logError,
+        jest.fn(),
+        3
+    )
+
+    streamer.start()
+    expect(mockXHR.send).toHaveBeenCalled()
+
+    mockXHR.onerror({} as ProgressEvent)
+    // Simulate stream failure and fallback to polling
+    mockXHR.onerror({} as ProgressEvent)
+    // jest.advanceTimersByTime(getRandom(1000, 10000))
+
+    // Ensure polling has started
+    expect(poller.start).toHaveBeenCalled()
+
+    // Now close the streamer
+    streamer.close()
+
+    expect(mockXHR.abort).toHaveBeenCalled()
+    expect(poller.stop).toHaveBeenCalled()
+    expect(mockEventBus.emit).toHaveBeenCalledWith(Event.STOPPED)
+  })
+
+  it('should stop streaming but not call poller.stop if not in fallback polling mode when close is called', () => {
+    const poller = { start: jest.fn(), stop: jest.fn(), isPolling: jest.fn().mockReturnValue(false) } as unknown as Poller
+    const streamer = new Streamer(
+        mockEventBus,
+        { baseUrl: 'http://test', eventUrl: 'http://event', pollingEnabled: true, streamEnabled: true, debug: true },
+        'http://test/stream',
+        'test-api-key',
+        { 'Test-Header': 'value' },
+        poller,
+        logDebug,
+        logError,
+        jest.fn(),
+        3
+    )
+
+    streamer.start()
+    streamer.close()
+
+    expect(mockXHR.abort).toHaveBeenCalled()
+    expect(poller.stop).not.toHaveBeenCalled()
+    expect(mockEventBus.emit).toHaveBeenCalledWith(Event.STOPPED)
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -543,7 +543,8 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
         } else if (event.domain === 'target-segment') {
           handleSegmentEvent(event)
         }
-      }
+      },
+      configurations.maxStreamingRetries
     )
     eventSource.start()
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -544,7 +544,7 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
           handleSegmentEvent(event)
         }
       },
-      configurations.maxStreamingRetries
+      configurations.maxStreamRetries
     )
     eventSource.start()
   }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -11,7 +11,8 @@ export class Streamer {
   private readTimeoutCheckerId: any
   private connectionOpened = false
   private disconnectEventEmitted = false
-  private reconnectAttempts = 0 
+  private reconnectAttempts = 0
+
 
   constructor(
     private eventBus: Emitter,
@@ -22,8 +23,10 @@ export class Streamer {
     private fallbackPoller: Poller,
     private logDebug: (...data: any[]) => void,
     private logError: (...data: any[]) => void,
-    private eventCallback: (e: StreamEvent) => void
-  ) {}
+    private eventCallback: (e: StreamEvent) => void,
+    private maxRetries: number
+
+) {}
 
   start() {
     const processData = (data: any): void => {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -13,7 +13,6 @@ export class Streamer {
   private disconnectEventEmitted = false
   private reconnectAttempts = 0
 
-
   constructor(
     private eventBus: Emitter,
     private configurations: Options,
@@ -25,8 +24,7 @@ export class Streamer {
     private logError: (...data: any[]) => void,
     private eventCallback: (e: StreamEvent) => void,
     private maxRetries: number
-
-) {}
+  ) {}
 
   start() {
     const processData = (data: any): void => {
@@ -63,7 +61,9 @@ export class Streamer {
         )
       }
 
-      setTimeout(() => this.start(), reconnectDelayMs)
+      if (this.reconnectAttempts < this.maxRetries) {
+        setTimeout(() => this.start(), reconnectDelayMs)
+      }
     }
 
     const onFailed = (msg: string) => {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -67,7 +67,9 @@ export class Streamer {
         if (this.configurations.pollingEnabled) {
           this.logErrorMessage('Max streaming retries reached. Staying in polling mode.')
         } else {
-          this.logErrorMessage('Max streaming retries reached.')
+          this.logErrorMessage(
+            'Max streaming retries reached. Polling mode is disabled and will receive no further flag updates until SDK client is restarted.'
+          )
         }
         return
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -149,8 +149,7 @@ export interface Options {
    * By default, the stream will attempt to reconnect indefinitely if it disconnects. Use this option to limit
    * the number of attempts it will make.
    */
-  maxStreamRetries?: number; // add this line
-
+  maxStreamRetries?: number
 }
 
 export interface MetricsInfo {

--- a/src/types.ts
+++ b/src/types.ts
@@ -144,6 +144,13 @@ export interface Options {
    * @default console
    */
   logger?: Logger
+
+  /**
+   * By default, the stream will attempt to reconnect indefinitely if it disconnects. Use this option to limit
+   * the number of attempts it will make.
+   */
+  maxStreamingRetries?: number; // add this line
+
 }
 
 export interface MetricsInfo {

--- a/src/types.ts
+++ b/src/types.ts
@@ -149,7 +149,7 @@ export interface Options {
    * By default, the stream will attempt to reconnect indefinitely if it disconnects. Use this option to limit
    * the number of attempts it will make.
    */
-  maxStreamingRetries?: number; // add this line
+  maxStreamRetries?: number; // add this line
 
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,7 +10,8 @@ export const defaultOptions: Options = {
   eventsSyncInterval: MIN_EVENTS_SYNC_INTERVAL,
   pollingInterval: MIN_POLLING_INTERVAL,
   streamEnabled: true,
-  cache: false
+  cache: false,
+  maxStreamingRetries: Infinity
 }
 
 export const getConfiguration = (options: Options): Options => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,7 +11,7 @@ export const defaultOptions: Options = {
   pollingInterval: MIN_POLLING_INTERVAL,
   streamEnabled: true,
   cache: false,
-  maxStreamingRetries: Infinity
+  maxStreamRetries: Infinity
 }
 
 export const getConfiguration = (options: Options): Options => {


### PR DESCRIPTION
# What
Adds a config option called `maxStreamRetries` to limit the retries that occur if the stream disconnects.  By default, the retries remain at `Infinite` which is the existing behaviour.  If retries are exhausted, one of two states can occur

1. If Polling is enabled, the SDK will remain in polling mode and no further streaming reconnection attempts will be made.  The default polling option, if not supplied, is whatever the `streamingEnabled` value is. 
or 
2. If polling is disabled, the SDK will not get any further evaluation updates for the remainder of the SDK client instance's life. The SDK will need re-initialised, e.g the app being restarted, to get new evaluations in this state.

# Why
A customer has asked for a way to limit stream retries

# Testing
New unit tests for the `Streamer` class. 

Manual using local proxy tool to simulate disconnections. 