### PR TITLE
FFM-11852 Stop fallback Poller if stream resumes during a polling request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-javascript-client-sdk",
-  "version": "1.27.0-rc.0",
+  "version": "1.27.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.27.0-rc.0",
+      "version": "1.27.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-javascript-client-sdk",
-  "version": "1.27.0-rc.0",
+  "version": "1.27.0",
   "author": "Harness",
   "license": "Apache-2.0",
   "main": "dist/sdk.cjs.js",

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -32,8 +32,12 @@ export default class Poller {
   }
 
   private poll(): void {
+    if (!this.isRunning) return
     this.attemptFetch().finally(() => {
-      this.timeoutId = setTimeout(() => this.poll(), this.configurations.pollingInterval)
+      // Check if poller is still running before setting the next timeout
+      if (this.isRunning) {
+        this.timeoutId = setTimeout(() => this.poll(), this.configurations.pollingInterval)
+      }
     })
   }
 
@@ -70,9 +74,9 @@ export default class Poller {
 
   public stop(): void {
     if (this.timeoutId) {
+      this.isRunning = false
       clearTimeout(this.timeoutId)
       this.timeoutId = undefined
-      this.isRunning = false
       this.eventBus.emit(Event.POLLING_STOPPED)
       this.logDebugMessage('Polling stopped')
     }


### PR DESCRIPTION
# What
Fixes an edge case where if the stream disconnects and resumes during a request made by the fallback poller (60 seconds later), the fallback poller will not be disabled and will continue polling for the lifetime of the SDK instance.

# Testing
Manual using local proxy tool to simulate stream disconnects and observed no third `evaluations` request once the stream reconnected. 
![Screenshot 2024-08-12 at 15 07 54](https://github.com/user-attachments/assets/4edc55e3-4fc1-4911-a5f4-c16fa101c785)
