### PR TITLE
FFM-12129 Add new event for default variation being returned

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ client.on(Event.ERROR_STREAM, error => {
 
 ### Getting value for a particular feature flag
 
-If you would like to know that the default variation was returned when getting the value, for example, if the provided flag identifier wasn't found then pass true for the third argument withDebug:
+If you would like to know that the default variation was returned when getting the value, for example, if the provided flag wasn't found in the cache then pass true for the third argument withDebug:
 ```typescript
 const result = client.variation('Dark_Theme', false, true);
 ```
@@ -248,6 +248,23 @@ For the example above:
 
 - If the flag identifier 'Dark_Theme' exists in storage, variationValue would be the stored value for that identifier.
 - If the flag identifier 'Dark_Theme' does not exist, variationValue would be the default value provided, in this case, false
+
+* Note the reasons for the default variation being returned can be
+  1. SDK Not Initialized Yet
+  2. Typo in Flag Identifier
+  3. Wrong project API key being used
+
+#### Listening for the `ERROR_DEFAULT_VARIATION_RETURNED` event
+You can also listen for the `ERROR_DEFAULT_VARIATION_RETURNED` event, which is emitted whenever a default variation is returned because the flag has not been found in the cache. This is useful for logging or taking other action when a flag is not found. 
+
+Example of listening for the event:
+
+```typescript
+client.on(Event.ERROR_DEFAULT_VARIATION_RETURNED, ({ flag, valueReturned }) => {
+  console.warn(`Default variation returned for flag: ${flag}, value: ${valueReturned}`)
+})
+```
+
 ### Cleaning up
 
 Remove a listener of an event by `client.off`.

--- a/README.md
+++ b/README.md
@@ -260,8 +260,8 @@ You can also listen for the `ERROR_DEFAULT_VARIATION_RETURNED` event, which is e
 Example of listening for the event:
 
 ```typescript
-client.on(Event.ERROR_DEFAULT_VARIATION_RETURNED, ({ flag, valueReturned }) => {
-  console.warn(`Default variation returned for flag: ${flag}, value: ${valueReturned}`)
+client.on(Event.ERROR_DEFAULT_VARIATION_RETURNED, ({ flag, defaultVariation }) => {
+  console.warn(`Default variation returned for flag: ${flag}, value: ${defaultVariation}`)
 })
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-javascript-client-sdk",
-  "version": "1.28.0",
+  "version": "1.29.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.28.0",
+      "version": "1.29.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "format": "prettier --write \"src/**/*.ts\"",
     "type": "tsc ./src/*.ts --declaration --emitDeclarationOnly --outDir dist --lib ES2015,DOM",
     "clean": "rm -rf ./dist",
-    "test": "jest"
+    "test": "jest",
+    "prepare": "npm run build"
   },
   "devDependencies": {
     "@types/jest": "^29.5.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-javascript-client-sdk",
-  "version": "1.28.0",
+  "version": "1.29.0",
   "author": "Harness",
   "license": "Apache-2.0",
   "main": "dist/sdk.cjs.js",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "format": "prettier --write \"src/**/*.ts\"",
     "type": "tsc ./src/*.ts --declaration --emitDeclarationOnly --outDir dist --lib ES2015,DOM",
     "clean": "rm -rf ./dist",
-    "test": "jest",
-    "prepare": "npm run build"
+    "test": "jest"
   },
   "devDependencies": {
     "@types/jest": "^29.5.4",

--- a/src/__tests__/variation.test.ts
+++ b/src/__tests__/variation.test.ts
@@ -1,6 +1,6 @@
 import { getVariation } from '../variation'
 import type { Emitter } from 'mitt'
-import {Event} from "../types";
+import { Event } from '../types'
 
 describe('getVariation', () => {
   describe('without debug', () => {
@@ -31,7 +31,7 @@ describe('getVariation', () => {
         all: new Map()
       }
 
-      const defaultValue = false;
+      const defaultValue = false
       const result = getVariation('testFlag', defaultValue, storage, mockMetricsHandler, mockEventBus)
 
       expect(result).toBe(defaultValue)
@@ -74,7 +74,7 @@ describe('getVariation', () => {
         all: new Map()
       }
 
-      const defaultValue = false;
+      const defaultValue = false
       const result = getVariation('testFlag', defaultValue, storage, mockMetricsHandler, mockEventBus, true)
 
       expect(result).toEqual({ value: defaultValue, isDefaultValue: true })

--- a/src/__tests__/variation.test.ts
+++ b/src/__tests__/variation.test.ts
@@ -39,7 +39,7 @@ describe('getVariation', () => {
 
       expect(mockEventBus.emit).toHaveBeenCalledWith(Event.ERROR_DEFAULT_VARIATION_RETURNED, {
         flag: 'testFlag',
-        valueReturned: defaultValue
+        defaultVariation: defaultValue
       })
     })
   })
@@ -81,7 +81,7 @@ describe('getVariation', () => {
       expect(mockMetricsHandler).not.toHaveBeenCalled()
       expect(mockEventBus.emit).toHaveBeenCalledWith(Event.ERROR_DEFAULT_VARIATION_RETURNED, {
         flag: 'testFlag',
-        valueReturned: defaultValue
+        defaultVariation: defaultValue
       })
     })
   })

--- a/src/__tests__/variation.test.ts
+++ b/src/__tests__/variation.test.ts
@@ -1,6 +1,6 @@
 import { getVariation } from '../variation'
 import type { Emitter } from 'mitt'
-import { Event } from '../types'
+import {type DefaultVariationEventPayload, Event} from '../types'
 
 describe('getVariation', () => {
   describe('without debug', () => {
@@ -37,10 +37,9 @@ describe('getVariation', () => {
       expect(result).toBe(defaultValue)
       expect(mockMetricsHandler).not.toHaveBeenCalled()
 
-      expect(mockEventBus.emit).toHaveBeenCalledWith(Event.ERROR_DEFAULT_VARIATION_RETURNED, {
-        flag: 'testFlag',
-        defaultVariation: defaultValue
-      })
+      const expectedEvent: DefaultVariationEventPayload = { flag: 'testFlag', defaultVariation: defaultValue }
+
+      expect(mockEventBus.emit).toHaveBeenCalledWith(Event.ERROR_DEFAULT_VARIATION_RETURNED, expectedEvent)
     })
   })
 
@@ -79,10 +78,10 @@ describe('getVariation', () => {
 
       expect(result).toEqual({ value: defaultValue, isDefaultValue: true })
       expect(mockMetricsHandler).not.toHaveBeenCalled()
-      expect(mockEventBus.emit).toHaveBeenCalledWith(Event.ERROR_DEFAULT_VARIATION_RETURNED, {
-        flag: 'testFlag',
-        defaultVariation: defaultValue
-      })
+
+      const expectedEvent: DefaultVariationEventPayload = { flag: 'testFlag', defaultVariation: defaultValue }
+
+      expect(mockEventBus.emit).toHaveBeenCalledWith(Event.ERROR_DEFAULT_VARIATION_RETURNED, expectedEvent)
     })
   })
 })

--- a/src/__tests__/variation.test.ts
+++ b/src/__tests__/variation.test.ts
@@ -1,6 +1,6 @@
 import { getVariation } from '../variation'
 import type { Emitter } from 'mitt'
-import {type DefaultVariationEventPayload, Event} from '../types'
+import { type DefaultVariationEventPayload, Event } from '../types'
 
 describe('getVariation', () => {
   describe('without debug', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -678,7 +678,7 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
   }
 
   const variation = (identifier: string, defaultValue: any, withDebug = false) => {
-    return getVariation(identifier, defaultValue, storage, handleMetrics, withDebug)
+    return getVariation(identifier, defaultValue, storage, handleMetrics, eventBus, withDebug)
   }
 
   return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,8 @@ import type {
   StreamEvent,
   Target,
   VariationFn,
-  VariationValue
+  VariationValue,
+  DefaultVariationEventPayload
 } from './types'
 import { Event } from './types'
 import { defer, encodeTarget, getConfiguration } from './utils'
@@ -702,5 +703,6 @@ export {
   EventOffBinding,
   Result,
   Evaluation,
-  VariationValue
+  VariationValue,
+  DefaultVariationEventPayload
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,11 @@ export interface VariationValueWithDebug {
   isDefaultValue: boolean
 }
 
+export interface DefaultVariationEventPayload {
+  flag: string
+  defaultVariation: VariationValue
+}
+
 export interface Evaluation {
   flag: string // Feature flag identifier
   identifier: string // variation identifier

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,7 +73,7 @@ export interface EventCallbackMapping {
   [Event.ERROR_FETCH_FLAG]: (error: unknown) => void
   [Event.ERROR_STREAM]: (error: unknown) => void
   [Event.ERROR_METRICS]: (error: unknown) => void
-  [Event.ERROR_DEFAULT_VARIATION_RETURNED]: (payload: { flag: string; defaultVariation: VariationValue }) => void
+  [Event.ERROR_DEFAULT_VARIATION_RETURNED]: (payload: DefaultVariationEventPayload) => void
 }
 
 export type EventOnBinding = <K extends keyof EventCallbackMapping>(event: K, callback: EventCallbackMapping[K]) => void

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,7 +68,7 @@ export interface EventCallbackMapping {
   [Event.ERROR_FETCH_FLAG]: (error: unknown) => void
   [Event.ERROR_STREAM]: (error: unknown) => void
   [Event.ERROR_METRICS]: (error: unknown) => void
-  [Event.ERROR_DEFAULT_VARIATION_RETURNED]: (payload: { flag: string; valueReturned: VariationValue }) => void
+  [Event.ERROR_DEFAULT_VARIATION_RETURNED]: (payload: { flag: string; defaultVariation: VariationValue }) => void
 }
 
 export type EventOnBinding = <K extends keyof EventCallbackMapping>(event: K, callback: EventCallbackMapping[K]) => void

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,7 @@ export interface EventCallbackMapping {
   [Event.ERROR_FETCH_FLAG]: (error: unknown) => void
   [Event.ERROR_STREAM]: (error: unknown) => void
   [Event.ERROR_METRICS]: (error: unknown) => void
+  [Event.ERROR_DEFAULT_VARIATION_RETURNED]: (payload: { flag: string; valueReturned: VariationValue }) => void
 }
 
 export type EventOnBinding = <K extends keyof EventCallbackMapping>(event: K, callback: EventCallbackMapping[K]) => void

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,8 @@ export enum Event {
   ERROR_AUTH = 'auth error',
   ERROR_FETCH_FLAGS = 'fetch flags error',
   ERROR_FETCH_FLAG = 'fetch flag error',
-  ERROR_STREAM = 'stream error'
+  ERROR_STREAM = 'stream error',
+  ERROR_DEFAULT_VARIATION_RETURNED = 'default variation returned'
 }
 
 export type VariationValue = boolean | string | number | object | undefined

--- a/src/variation.ts
+++ b/src/variation.ts
@@ -1,4 +1,4 @@
-import {type DefaultVariationEventPayload, Event, type VariationValue, type VariationValueWithDebug} from './types'
+import { type DefaultVariationEventPayload, Event, type VariationValue, type VariationValueWithDebug } from './types'
 import type { Emitter } from 'mitt'
 
 export function getVariation(
@@ -16,7 +16,8 @@ export function getVariation(
     metricsHandler(identifier, value)
   } else {
     const payload: DefaultVariationEventPayload = { flag: identifier, defaultVariation: defaultValue }
-    eventBus.emit(Event.ERROR_DEFAULT_VARIATION_RETURNED, payload)  }
+    eventBus.emit(Event.ERROR_DEFAULT_VARIATION_RETURNED, payload)
+  }
 
   return !withDebug ? value : { value, isDefaultValue: !identifierExists }
 }

--- a/src/variation.ts
+++ b/src/variation.ts
@@ -1,10 +1,12 @@
-import type { VariationValue, VariationValueWithDebug } from './types'
+import {Event, type VariationValue, type VariationValueWithDebug} from './types'
+import type {Emitter} from "mitt";
 
 export function getVariation(
   identifier: string,
   defaultValue: any,
   storage: Record<string, any>,
   metricsHandler: (flag: string, value: any) => void,
+  eventBus: Emitter,
   withDebug?: boolean
 ): VariationValue | VariationValueWithDebug {
   const identifierExists = identifier in storage
@@ -12,6 +14,8 @@ export function getVariation(
 
   if (identifierExists) {
     metricsHandler(identifier, value)
+  } else {
+    eventBus.emit(Event.ERROR_DEFAULT_VARIATION_RETURNED, { flag: identifier, valueReturned: defaultValue })
   }
 
   return !withDebug ? value : { value, isDefaultValue: !identifierExists }

--- a/src/variation.ts
+++ b/src/variation.ts
@@ -1,4 +1,4 @@
-import { Event, type VariationValue, type VariationValueWithDebug } from './types'
+import {type DefaultVariationEventPayload, Event, type VariationValue, type VariationValueWithDebug} from './types'
 import type { Emitter } from 'mitt'
 
 export function getVariation(
@@ -15,8 +15,8 @@ export function getVariation(
   if (identifierExists) {
     metricsHandler(identifier, value)
   } else {
-    eventBus.emit(Event.ERROR_DEFAULT_VARIATION_RETURNED, { flag: identifier, valueReturned: defaultValue })
-  }
+    const payload: DefaultVariationEventPayload = { flag: identifier, defaultVariation: defaultValue }
+    eventBus.emit(Event.ERROR_DEFAULT_VARIATION_RETURNED, payload)  }
 
   return !withDebug ? value : { value, isDefaultValue: !identifierExists }
 }

--- a/src/variation.ts
+++ b/src/variation.ts
@@ -1,5 +1,5 @@
-import {Event, type VariationValue, type VariationValueWithDebug} from './types'
-import type {Emitter} from "mitt";
+import { Event, type VariationValue, type VariationValueWithDebug } from './types'
+import type { Emitter } from 'mitt'
 
 export function getVariation(
   identifier: string,


### PR DESCRIPTION
# What
Adds new event `ERROR_DEFAULT_VARIATION_RETURNED` that is emitted whenever a default variation is returned. 

# Testing
- Updated unit tests
- Manual with prod2 account