### PR TITLE
feat: [FFM-12306]: Enhance caching key

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,14 @@ interface CacheOptions {
   // storage mechanism to use, conforming to the Web Storage API standard, can be either synchronous or asynchronous
   // defaults to localStorage
   storage?: AsyncStorage | SyncStorage
+  /**
+   * use target attributes when deriving the cache key
+   * when set to `false` or omitted, the key will be formed using only the target identifier and SDK key
+   * when set to `true`, all target attributes with be used in addition to the target identifier and SDK key
+   * can be set to an array of target attributes to use a subset in addition to the target identifier and SDK key
+   * defaults to false
+   */
+  deriveKeyFromTargetAttributes?: boolean | string[]
 }
 ```
 
@@ -355,7 +363,7 @@ If the request is aborted due to this timeout the SDK will fail to initialize an
 
 The default value if not specified is `0` which means that no timeout will occur.
 
-**This only applies to the authentiaction request. If you wish to set a read timeout on the remaining requests made by the SDK, you may register [API Middleware](#api-middleware)
+**This only applies to the authentication request. If you wish to set a read timeout on the remaining requests made by the SDK, you may register [API Middleware](#api-middleware)
 
 ```typescript
 const options = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harnessio/ff-javascript-client-sdk",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@harnessio/ff-javascript-client-sdk",
-      "version": "1.29.0",
+      "version": "1.30.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^3.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2308,10 +2308,11 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -7817,9 +7818,9 @@
       "dev": true
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "requires": {
         "path-key": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/ff-javascript-client-sdk",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "author": "Harness",
   "license": "Apache-2.0",
   "main": "dist/sdk.cjs.js",

--- a/src/__tests__/cache.test.ts
+++ b/src/__tests__/cache.test.ts
@@ -1,5 +1,5 @@
-import type { AsyncStorage, Evaluation, SyncStorage } from '../types'
-import { getCache } from '../cache'
+import type { AsyncStorage, Evaluation, SyncStorage, Target } from '../types'
+import { createCacheIdSeed, getCache } from '../cache'
 
 const sampleEvaluations: Evaluation[] = [
   { flag: 'flag1', value: 'false', kind: 'boolean', identifier: 'false' },
@@ -147,5 +147,40 @@ describe('getCache', () => {
 
       expect(setItemMock).not.toHaveBeenCalled()
     })
+  })
+})
+
+describe('createCacheIdSeed', () => {
+  const apiKey = 'abc123'
+  const target: Target = {
+    name: 'Test Name',
+    identifier: 'test-identifier',
+    attributes: {
+      a: 'bcd',
+      b: 123,
+      c: ['x', 'y', 'z']
+    }
+  }
+
+  test('it should return the target id and api key when deriveKeyFromTargetAttributes is omitted', async () => {
+    expect(createCacheIdSeed(target, apiKey)).toEqual(target.identifier + apiKey)
+  })
+
+  test('it should return the target id and api key when deriveKeyFromTargetAttributes is false', async () => {
+    expect(createCacheIdSeed(target, apiKey, { deriveKeyFromTargetAttributes: false })).toEqual(
+      target.identifier + apiKey
+    )
+  })
+
+  test('it should return the target id and api key with all attributes when deriveKeyFromTargetAttributes is true', async () => {
+    expect(createCacheIdSeed(target, apiKey, { deriveKeyFromTargetAttributes: true })).toEqual(
+      '{"a":"bcd","b":123,"c":["x","y","z"]}test-identifierabc123'
+    )
+  })
+
+  test('it should return the target id and api key with a subset of attributes when deriveKeyFromTargetAttributes is an array', async () => {
+    expect(createCacheIdSeed(target, apiKey, { deriveKeyFromTargetAttributes: ['a', 'c'] })).toEqual(
+      '{"a":"bcd","c":["x","y","z"]}test-identifierabc123'
+    )
   })
 })

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,4 +1,5 @@
 import type { AsyncStorage, CacheOptions, Evaluation, SyncStorage, Target } from './types'
+import { sortEvaluations } from './utils'
 
 export interface GetCacheResponse {
   loadFromCache: () => Promise<Evaluation[]>
@@ -48,7 +49,7 @@ async function clearCachedEvaluations(cacheId: string, storage: AsyncStorage): P
 }
 
 async function saveToCache(cacheId: string, storage: AsyncStorage, evaluations: Evaluation[]): Promise<void> {
-  await storage.setItem(cacheId, JSON.stringify(evaluations))
+  await storage.setItem(cacheId, JSON.stringify(sortEvaluations(evaluations)))
   await storage.setItem(cacheId + '.ts', Date.now().toString())
 }
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,4 +1,4 @@
-import type { AsyncStorage, CacheOptions, Evaluation, SyncStorage } from './types'
+import type { AsyncStorage, CacheOptions, Evaluation, SyncStorage, Target } from './types'
 
 export interface GetCacheResponse {
   loadFromCache: () => Promise<Evaluation[]>
@@ -74,6 +74,28 @@ async function removeCachedEvaluation(cacheId: string, storage: AsyncStorage, fl
 
     await saveToCache(cacheId, storage, cachedEvals)
   }
+}
+
+export function createCacheIdSeed(target: Target, apiKey: string, config: CacheOptions = {}) {
+  if (!config.deriveKeyFromTargetAttributes) return target.identifier + apiKey
+
+  return (
+    JSON.stringify(
+      Object.keys(target.attributes || {})
+        .sort()
+        .filter(
+          attribute =>
+            !Array.isArray(config.deriveKeyFromTargetAttributes) ||
+            config.deriveKeyFromTargetAttributes.includes(attribute)
+        )
+        .reduce(
+          (filteredAttributes, attribute) => ({ ...filteredAttributes, [attribute]: target.attributes[attribute] }),
+          {}
+        )
+    ) +
+    target.identifier +
+    apiKey
+  )
 }
 
 async function getCacheId(seed: string): Promise<string> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import { addMiddlewareToFetch } from './request'
 import { Streamer } from './stream'
 import { getVariation } from './variation'
 import Poller from './poller'
-import { getCache } from './cache'
+import { createCacheIdSeed, getCache } from './cache'
 
 const SDK_VERSION = '1.26.1'
 const SDK_INFO = `Javascript ${SDK_VERSION} Client`
@@ -110,10 +110,9 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
       try {
         let initialLoad = true
 
-        const cache = await getCache(
-          target.identifier + apiKey,
-          typeof configurations.cache === 'boolean' ? {} : configurations.cache
-        )
+        const cacheConfig = typeof configurations.cache === 'boolean' ? {} : configurations.cache
+
+        const cache = await getCache(createCacheIdSeed(target, apiKey, cacheConfig), cacheConfig)
 
         const cachedEvaluations = await cache.loadFromCache()
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import type {
   DefaultVariationEventPayload
 } from './types'
 import { Event } from './types'
-import { defer, encodeTarget, getConfiguration } from './utils'
+import { defer, encodeTarget, getConfiguration, sortEvaluations } from './utils'
 import { addMiddlewareToFetch } from './request'
 import { Streamer } from './stream'
 import { getVariation } from './variation'
@@ -440,7 +440,7 @@ const initialize = (apiKey: string, target: Target, options?: Options): Result =
       )
 
       if (res.ok) {
-        const data = await res.json()
+        const data = sortEvaluations(await res.json())
         data.forEach(registerEvaluation)
         eventBus.emit(Event.FLAGS_LOADED, data)
         return { type: 'success', data: data }

--- a/src/types.ts
+++ b/src/types.ts
@@ -196,6 +196,14 @@ export interface CacheOptions {
    * @default localStorage
    */
   storage?: AsyncStorage | SyncStorage
+  /**
+   * Use target attributes when deriving the cache key
+   * When set to `false` or omitted, the key will be formed using only the target identifier and SDK key
+   * When set to `true`, all target attributes with be used in addition to the target identifier and SDK key
+   * Can be set to an array of target attributes to use a subset in addition to the target identifier and SDK key
+   * @default false
+   */
+  deriveKeyFromTargetAttributes?: boolean | string[]
 }
 
 export interface Logger {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import type { Options, Target } from './types'
+import type { Evaluation, Options, Target } from './types'
 
 export const MIN_EVENTS_SYNC_INTERVAL = 60000
 export const MIN_POLLING_INTERVAL = 60000
@@ -99,3 +99,7 @@ const utf8encode = (str: string): string =>
       )
     })
     .join('')
+
+export function sortEvaluations(evaluations: Evaluation[]): Evaluation[] {
+  return [...evaluations].sort(({ flag: flagA }, { flag: flagB }) => (flagA < flagB ? -1 : 1))
+}


### PR DESCRIPTION
This PR adds the new `deriveKeyFromTargetAttributes` cache config option. This allows the use of target attributes when building up the key that's used to store and retrieve evaluations from the cache.

```typescript
// use all attributes when deriving key
const client = initialize(apiKey, target, {
  cache: {
    deriveKeyFromTargetAttributes: true
  }
})

// use subset of attributes when deriving key
const client = initialize(apiKey, target, {
  cache: {
    deriveKeyFromTargetAttributes: ['attributeA', 'attributeB']
  }
})
```